### PR TITLE
feat: dashboard, usage tracking, Coolify deploy & VN docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 config.yaml
 certs/
 clients/
+.omc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,8 @@ COPY package.json ./
 RUN mkdir -p /app/data
 
 EXPOSE 8443
-CMD ["node", "dist/index.js", "/app/config.yaml"]
+# Config path defaults to /app/data/config.yaml (persistent volume).
+# If missing on first start, the container auto-generates it from
+# CCG_REFRESH_TOKEN env or a mounted credentials.json. Override path with
+# CCG_CONFIG_PATH env or by passing an arg to node.
+CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22-slim AS builder
 WORKDIR /app
+# Build tools needed by better-sqlite3 if no prebuilt binary matches the runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json* ./
 RUN npm install
 COPY tsconfig.json ./
@@ -11,6 +15,7 @@ WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY package.json ./
+RUN mkdir -p /app/data
 
 EXPOSE 8443
 CMD ["node", "dist/index.js", "/app/config.yaml"]

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,344 @@
+# CC Gateway — Hướng dẫn Deploy & Sử dụng Local
+
+Tài liệu tiếng Việt mô tả cách triển khai CC Gateway và cách dùng ở môi trường local. Bản tiếng Anh đầy đủ ở [`README.md`](README.md).
+
+CC Gateway là một reverse proxy đứng giữa Claude Code và Anthropic API, làm nhiệm vụ chuẩn hoá identity (device ID, email, env, headers, prompt, billing header…) để nhiều máy có thể dùng chung một subscription mà chỉ "lộ" ra một danh tính duy nhất.
+
+---
+
+## 1. Yêu cầu
+
+- **Node.js 22+** (chạy trực tiếp) hoặc **Docker + Docker Compose** (chạy container).
+- Đã đăng nhập Claude Code trên máy admin ít nhất một lần (để có OAuth credentials trong macOS Keychain hoặc `~/.claude/.credentials.json`).
+- `python3`, `openssl`, `bash` (script setup cần đến).
+- Tuỳ chọn: HTTP/HTTPS proxy (Clash, V2Ray…) nếu mạng cần.
+
+Kiểm tra nhanh:
+
+```bash
+node -v          # >= v22
+docker -v        # nếu định deploy bằng Docker
+claude --version # đảm bảo đã login Claude Code
+```
+
+---
+
+## 2. Chạy local (development)
+
+### 2.1. Setup một câu lệnh
+
+```bash
+git clone https://github.com/motiful/cc-gateway.git
+cd cc-gateway
+npm install
+bash scripts/quick-setup.sh
+```
+
+Script `quick-setup.sh` sẽ:
+
+1. Đọc OAuth token (access + refresh + expires) từ Keychain hoặc `~/.claude/.credentials.json`.
+2. Sinh `device_id` và `client_token` ngẫu nhiên.
+3. Ghi `config.yaml` ở thư mục gốc.
+4. Tạo launcher cho client đầu tiên ở `./clients/cc-<hostname>`.
+5. Khởi động gateway ở `http://localhost:8443` bằng `npm run dev` (tsx watch, auto-reload).
+
+Nếu `config.yaml` đã tồn tại, script chỉ start gateway, không ghi đè config.
+
+### 2.2. Sử dụng
+
+Mở terminal khác:
+
+```bash
+./clients/cc-<hostname>
+```
+
+Claude Code sẽ chạy và toàn bộ traffic đi qua gateway. Mọi tham số gốc của `claude` đều dùng được, ví dụ:
+
+```bash
+./clients/cc-<hostname> --print "hello"
+./clients/cc-<hostname> --resume
+```
+
+### 2.3. Cài làm lệnh `ccg` cho tiện
+
+```bash
+chmod +x ./clients/cc-<hostname>
+./clients/cc-<hostname> install   # tạo lệnh `ccg` toàn hệ thống
+ccg                               # chạy Claude Code qua gateway
+ccg status                        # xem trạng thái kết nối + hijack
+ccg help                          # liệt kê toàn bộ subcommand
+```
+
+Tuỳ chọn "hijack" để lệnh `claude` mặc định cũng đi qua gateway:
+
+```bash
+ccg hijack    # alias claude → ccg (terminal mới tự áp dụng)
+ccg release   # huỷ hijack, trả lại claude gốc
+ccg native    # chạy claude gốc một lần, bỏ qua gateway
+```
+
+### 2.4. Thêm client (cho user khác trong team)
+
+Có hai cách: dùng dashboard web (mục 4) hoặc dùng script:
+
+```bash
+bash scripts/add-client.sh alice
+bash scripts/add-client.sh bob
+```
+
+Script sẽ:
+- Sinh token mới và append vào `config.yaml` (gateway hot-reload trong ~2 giây nhờ `watchFile`).
+- Tạo file `./clients/cc-alice`, `./clients/cc-bob`.
+
+Gửi nguyên file launcher cho user — không cần share `config.yaml`, không cần OAuth login lại.
+
+Mặc định launcher trỏ về `http://localhost:8443`. Để trỏ tới gateway từ xa:
+
+```bash
+bash scripts/add-client.sh alice "" gateway.example.com:8443 https
+```
+
+Bốn tham số: `<tên> [token] [host:port] [scheme]`. Token để rỗng (`""`) sẽ tự sinh.
+
+### 2.5. Chạy sau lưng proxy
+
+```bash
+HTTPS_PROXY=http://127.0.0.1:7890 bash scripts/quick-setup.sh
+# hoặc chạy thủ công:
+HTTPS_PROXY=http://127.0.0.1:7890 npm run dev
+```
+
+Gateway tôn trọng `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` cho cả request lên Anthropic API lẫn refresh token.
+
+### 2.6. Lệnh npm hữu ích
+
+```bash
+npm run dev                      # tsx watch, auto-reload
+npm run build                    # biên dịch TypeScript ra dist/
+npm start                        # chạy bản đã build
+npm test                         # chạy test rewriter
+npm run add-user -- <username>   # tạo user đăng nhập dashboard (bản đã build)
+npm run add-user:dev -- <username>  # tương tự, chạy bằng tsx
+npm run generate-token           # sinh token rời
+npm run generate-identity        # sinh identity rời
+```
+
+> **Lưu ý:** `add-user` tạo tài khoản đăng nhập **dashboard web** (lưu trong SQLite ở `./data/ccg.db`), khác với `add-client.sh` (tạo launcher Claude Code cho client). Xem chi tiết ở mục 4.
+
+---
+
+## 3. Deploy bằng Docker (production)
+
+### 3.1. Setup tự động
+
+Trên máy admin (đã login Claude Code):
+
+```bash
+bash scripts/admin-setup.sh
+```
+
+Script sẽ hỏi tương tác:
+1. Lấy OAuth credentials.
+2. Tạo `config.yaml` + launcher cho client đầu tiên.
+3. Build và `docker compose up -d`.
+4. Hỏi địa chỉ public mà client sẽ kết nối tới.
+
+Sau khi container chạy, kiểm tra:
+
+```bash
+docker compose ps
+docker compose logs -f gateway
+curl http://localhost:8443/_health   # phải trả về 200
+```
+
+### 3.2. Thêm client sau khi đã deploy
+
+```bash
+bash scripts/add-client.sh charlie "" your-domain.com:443 https
+docker compose restart        # nạp lại danh sách token
+```
+
+`docker-compose.yml` mount `ccg_data` (volume) để giữ `config.yaml` + SQLite giữa các lần restart, nên `device_id` và token sẽ không bị reset.
+
+### 3.3. Deploy với Coolify (sẵn cấu hình)
+
+`docker-compose.yml` đã có sẵn label cho Coolify + Traefik:
+- Tạo service mới trên Coolify, point tới repo này.
+- Set domain (Coolify tự sinh `SERVICE_FQDN_GATEWAY`).
+- Traefik sẽ tự cấp Let's Encrypt cert và redirect HTTP → HTTPS.
+- Mount `~/.claude/.credentials.json` ở host vào `/app/data/claude-credentials.json` (read-only) để container tự bootstrap config lần đầu.
+
+### 3.4. Deploy thủ công với TLS tự ký
+
+Khi cần TLS mà không có domain công khai:
+
+```bash
+mkdir certs
+openssl req -x509 -newkey rsa:2048 \
+  -keyout certs/key.pem -out certs/cert.pem \
+  -days 365 -nodes -subj "/CN=cc-gateway"
+```
+
+Bỏ comment phần `tls` trong `config.yaml`, sau đó sinh launcher với scheme `https`:
+
+```bash
+bash scripts/add-client.sh alice "" <gateway-ip>:8443 https
+```
+
+Launcher tự thêm `NODE_TLS_REJECT_UNAUTHORIZED=0` để chấp nhận self-signed cert.
+
+### 3.5. Tailscale (lựa chọn nhẹ nhất)
+
+Nếu mọi máy đều có Tailscale, chạy gateway trên một máy bất kỳ trong mesh — không cần TLS, không cần public IP, không cần forward port. Trỏ launcher tới hostname Tailscale (vd: `gateway.tailnet-xxx.ts.net:8443`).
+
+### 3.6. Auto-bootstrap config khi khởi động
+
+Khi container start lần đầu mà chưa có `config.yaml` ở `/app/data/config.yaml` (hoặc đường dẫn trong `CCG_CONFIG_PATH`), gateway sẽ tự sinh config từ một trong các nguồn sau:
+
+- `CCG_REFRESH_TOKEN` env var (nếu set).
+- File `claude-credentials.json` mount vào (mặc định `/app/data/claude-credentials.json`, read-only).
+
+`docker-compose.yml` đã cấu hình mount sẵn `/root/.claude/.credentials.json` của host vào path này, nên trên server vừa cài Claude Code chỉ cần `docker compose up -d` là gateway tự bootstrap.
+
+Ngoài ra:
+- **Token rotation persist**: mỗi lần OAuth refresh, refresh token mới được ghi đè vào `config.yaml` để restart không bị "replay" token đã tiêu thụ.
+- **Sync from credentials**: nếu host chạy `claude` và rotate token, gateway phát hiện `refresh_token` trong `credentials.json` khác với `config.yaml` và đồng bộ lại trước khi load.
+
+Có thể sinh thủ công `config.yaml` từ login Claude hiện có:
+
+```bash
+bash scripts/gen-config.sh --client whiletrue0x > config.yaml
+# hoặc ghi thẳng vào file Coolify volume:
+bash scripts/gen-config.sh --out /data/coolify/applications/<id>/config.yaml
+```
+
+---
+
+## 4. Dashboard web
+
+Gateway expose sẵn một dashboard quản trị ở chính port 8443 (`/dashboard`), không phải port riêng:
+
+| Path | Mục đích |
+|---|---|
+| `/` | Redirect → `/dashboard` (nếu đã login) hoặc `/login` |
+| `/login` | Form đăng nhập admin |
+| `/dashboard` | Xem usage/cost + quản lý client |
+| `/api/clients` | REST API list/create client (cookie session) |
+| `/api/clients/<name>` | REST API delete client |
+| `/_health` | Health check (không cần login) |
+
+### 4.1. Tạo user đăng nhập dashboard
+
+Lần đầu start, log sẽ cảnh báo `No dashboard users yet`. Tạo user:
+
+```bash
+# Local (dev)
+npm run add-user:dev -- admin
+
+# Trong container
+docker compose exec gateway node dist/scripts/add-user.js admin
+```
+
+Script hỏi password tương tác (>= 8 ký tự), hash bằng scrypt, lưu vào SQLite (`./data/ccg.db` hoặc `config.db.path`). Sau đó truy cập `http://localhost:8443/login`.
+
+### 4.2. Tính năng dashboard
+
+- **Quản lý client trong UI**: thêm/xoá launcher trực tiếp, copy lệnh cài đặt cho user.
+- **Per-request token usage & cost**: mỗi request lưu input / output / cache tokens riêng.
+- **Tổng hợp theo period**: today / 7 ngày / 30 ngày / all time.
+- **Hot-reload**: thêm/xoá client trong dashboard cập nhật `config.yaml` và gateway nạp lại token trong ~2 giây mà không cần restart.
+
+Pricing tính trong `src/pricing.ts`. Dữ liệu metric lưu SQLite, sống cùng volume `ccg_data` nên không mất khi redeploy.
+
+---
+
+## 5. Cấu trúc file quan trọng
+
+```
+cc-gateway/
+├── src/
+│   ├── index.ts         # entrypoint, watchFile config hot-reload
+│   ├── proxy.ts         # HTTP server, route dashboard + proxy upstream
+│   ├── dashboard.ts     # HTML cho /login + /dashboard
+│   ├── rewriter.ts      # rewrite identity, env, prompt, headers
+│   ├── oauth.ts         # quản lý access/refresh token
+│   ├── auth.ts          # auth bằng client token (proxy) + session (dashboard)
+│   ├── users.ts         # CRUD user dashboard (scrypt hash)
+│   ├── clients.ts       # CRUD client launcher
+│   ├── db.ts            # SQLite (better-sqlite3)
+│   ├── metrics.ts       # ghi nhận request + token usage
+│   ├── usage-parser.ts  # bóc tách input/output/cache token từ response
+│   ├── pricing.ts       # bảng giá theo model
+│   ├── bootstrap-config.ts  # auto-sinh config.yaml lần đầu
+│   ├── proxy-agent.ts   # honour HTTPS_PROXY / HTTP_PROXY
+│   ├── session.ts       # cookie session cho dashboard
+│   ├── config.ts        # parse YAML
+│   ├── logger.ts
+│   └── scripts/         # add-user, generate-token, generate-identity
+├── scripts/             # bash scripts dùng từ shell
+│   ├── quick-setup.sh   # setup + start local trong 1 lệnh
+│   ├── admin-setup.sh   # deploy Docker tương tác
+│   ├── add-client.sh    # thêm client + sinh launcher
+│   ├── extract-token.sh # rút OAuth token khỏi Keychain
+│   └── gen-config.sh    # sinh config.yaml từ login Claude hiện có
+├── clients/             # launcher cho từng user (gitignore)
+├── data/                # SQLite + config khi chạy local (gitignore)
+├── config.yaml          # config gateway (gitignore, do script sinh hoặc bootstrap)
+├── config.example.yaml  # mẫu để tham khảo cấu trúc
+├── docker-compose.yml   # deploy Docker + Coolify + Traefik
+├── Dockerfile           # multi-stage build Node 22
+└── clash-rules.yaml     # rule Clash chặn traffic trực tiếp tới Anthropic
+```
+
+---
+
+## 6. Troubleshooting
+
+| Triệu chứng | Nguyên nhân & cách xử lý |
+|---|---|
+| `Error: No Claude Code credentials found` | Chưa login Claude Code lần nào. Chạy `claude` trên máy admin, hoàn tất OAuth qua trình duyệt, rồi chạy lại setup. |
+| `No dashboard users yet` ở log | Chạy `npm run add-user -- <username>` (hoặc `docker compose exec gateway node dist/scripts/add-user.js <username>`) để tạo user trước khi vào `/login`. |
+| Gateway start xong nhưng client báo 401 | Token trong launcher không khớp `config.yaml`. Sinh lại launcher bằng `add-client.sh` với token đúng, hoặc kiểm tra mục `auth.tokens`. |
+| Anthropic trả 401 dù vừa refresh | Đảm bảo bản đang chạy là sau commit `497f46f` (forward OAuth qua `Authorization: Bearer` + `anthropic-beta`). Build lại nếu deploy bằng Docker. |
+| Refresh token bị "consumed" sau restart | Cần bản có `f22386e` — gateway tự ghi token rotated trở lại `config.yaml`. Kiểm tra quyền ghi của file/volume. |
+| Refresh token hết hạn (hiếm, sau vài tháng) | Chạy lại `bash scripts/extract-token.sh` trên máy admin, hoặc cập nhật `oauth.refresh_token` trong `config.yaml`. |
+| Request không qua proxy | Kiểm tra `HTTPS_PROXY` đã set khi start gateway chưa. Restart sau khi đổi env. |
+| Docker container không đọc được credentials | Đảm bảo mount `~/.claude/.credentials.json:/app/data/claude-credentials.json:ro` đúng; với non-root user, chỉnh path host cho phù hợp. |
+| Dashboard hiện 0 request dù client đang dùng | Kiểm tra `data/ccg.db` có quyền ghi; xem log `metrics`/`usage-parser` để bắt lỗi parse usage block. |
+| MCP request không đi qua gateway | `mcp-proxy.anthropic.com` hard-code, không theo `ANTHROPIC_BASE_URL`. Dùng Clash chặn nếu không cần MCP. |
+
+Log:
+- Local: stdout của `npm run dev`.
+- Docker: `docker compose logs -f gateway`.
+- Health check: `GET /_health`.
+
+---
+
+Log:
+- Local: stdout của `npm run dev`.
+- Docker: `docker compose logs -f gateway`.
+- Health check: `GET /_health`.
+
+---
+
+## 7. Các bước rút gọn
+
+**Local, một mình, một máy:**
+```bash
+npm install && bash scripts/quick-setup.sh
+npm run add-user:dev -- admin    # tạo user dashboard
+./clients/cc-<hostname> install
+ccg
+# mở http://localhost:8443 để xem dashboard
+```
+
+**Server Docker, nhiều client:**
+```bash
+bash scripts/admin-setup.sh
+docker compose exec gateway node dist/scripts/add-user.js admin
+# Thêm client qua dashboard hoặc:
+bash scripts/add-client.sh alice "" gateway.example.com:443 https
+# gửi file ./clients/cc-alice cho Alice (config tự hot-reload, không cần restart)
+```
+
+Xem [`README.md`](README.md) để biết chi tiết về cơ chế rewrite, OAuth lifecycle, Clash rules và các caveat.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -76,3 +76,9 @@ process:
 logging:
   level: info  # debug | info | warn | error
   audit: true  # log which client made each request
+
+# SQLite database — stores dashboard users and request metrics.
+# Path is relative to working directory. In Docker, mount /app/data as a volume
+# so the DB survives restarts. Create dashboard users with: npm run add-user <name>
+db:
+  path: ./data/ccg.db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,13 @@ services:
     expose:
       - "8443"
     volumes:
-      # config.yaml is provided via Coolify's "File Mount" (Storage tab) so the
-      # secrets stay out of git. The dashboard can append/remove client tokens
-      # at runtime; watchFile picks up edits within ~2s.
-      # For local dev, copy config.example.yaml → config.yaml and uncomment:
-      # - ./config.yaml:/app/config.yaml
+      # ccg_data persists both the SQLite DB and the auto-generated config.yaml
+      # (so device_id + tokens survive restarts/redeploys).
       - ccg_data:/app/data
+      # Optional: mount your existing claude credentials so the gateway can
+      # bootstrap config.yaml on first start without setting CCG_REFRESH_TOKEN.
+      # Uncomment + adjust the host path:
+      # - /root/.claude/.credentials.json:/app/data/claude-credentials.json:ro
     restart: unless-stopped
     networks:
       - coolify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,18 @@
 services:
   gateway:
     build: .
+    # Coolify auto-generates SERVICE_FQDN_GATEWAY from the domain configured
+    # in the service UI. Set the domain there (e.g. ccg.example.com) and
+    # Coolify will substitute it into the labels below at deploy time.
+    environment:
+      - SERVICE_FQDN_GATEWAY=/
     expose:
       - "8443"
     volumes:
-      - ./config.yaml:/app/config.yaml:ro
+      # Mounted read-write so the dashboard can append/remove client tokens.
+      # Hot-reload via watchFile picks up edits within ~2s.
+      - ./config.yaml:/app/config.yaml
+      - ccg_data:/app/data
     restart: unless-stopped
     networks:
       - coolify
@@ -21,12 +29,14 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=coolify"
-      - "traefik.http.routers.ccg.rule=Host(`ccg.toolvn.io.vn`)"
+      - "traefik.http.services.ccg.loadbalancer.server.port=8443"
+      # HTTPS router — Coolify substitutes SERVICE_FQDN_GATEWAY at deploy time
+      - "traefik.http.routers.ccg.rule=Host(`${SERVICE_FQDN_GATEWAY}`)"
       - "traefik.http.routers.ccg.entrypoints=https"
       - "traefik.http.routers.ccg.tls=true"
       - "traefik.http.routers.ccg.tls.certresolver=letsencrypt"
-      - "traefik.http.services.ccg.loadbalancer.server.port=8443"
-      - "traefik.http.routers.ccg-http.rule=Host(`ccg.toolvn.io.vn`)"
+      # HTTP → HTTPS redirect
+      - "traefik.http.routers.ccg-http.rule=Host(`${SERVICE_FQDN_GATEWAY}`)"
       - "traefik.http.routers.ccg-http.entrypoints=http"
       - "traefik.http.routers.ccg-http.middlewares=ccg-redirect"
       - "traefik.http.middlewares.ccg-redirect.redirectscheme.scheme=https"
@@ -35,3 +45,6 @@ services:
 networks:
   coolify:
     external: true
+
+volumes:
+  ccg_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,11 @@ services:
     expose:
       - "8443"
     volumes:
-      # Mounted read-write so the dashboard can append/remove client tokens.
-      # Hot-reload via watchFile picks up edits within ~2s.
-      - ./config.yaml:/app/config.yaml
+      # config.yaml is provided via Coolify's "File Mount" (Storage tab) so the
+      # secrets stay out of git. The dashboard can append/remove client tokens
+      # at runtime; watchFile picks up edits within ~2s.
+      # For local dev, copy config.example.yaml → config.yaml and uncomment:
+      # - ./config.yaml:/app/config.yaml
       - ccg_data:/app/data
     restart: unless-stopped
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,9 @@ services:
       # ccg_data persists both the SQLite DB and the auto-generated config.yaml
       # (so device_id + tokens survive restarts/redeploys).
       - ccg_data:/app/data
-      # Optional: mount your existing claude credentials so the gateway can
-      # bootstrap config.yaml on first start without setting CCG_REFRESH_TOKEN.
-      # Uncomment + adjust the host path:
-      # - /root/.claude/.credentials.json:/app/data/claude-credentials.json:ro
+      # Host's claude login credentials — read on first start to bootstrap
+      # config.yaml automatically. Read-only so the container cannot tamper.
+      - /root/.claude/.credentials.json:/app/data/claude-credentials.json:ro
     restart: unless-stopped
     networks:
       - coolify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   gateway:
     build: .
-    ports:
-      - "8443:8443"
+    expose:
+      - "8443"
     volumes:
       - ./config.yaml:/app/config.yaml:ro
-      - ./certs:/app/certs:ro
     restart: unless-stopped
+    networks:
+      - coolify
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:8443/_health').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"]
       interval: 30s
@@ -17,3 +18,20 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=coolify"
+      - "traefik.http.routers.ccg.rule=Host(`ccg.toolvn.io.vn`)"
+      - "traefik.http.routers.ccg.entrypoints=https"
+      - "traefik.http.routers.ccg.tls=true"
+      - "traefik.http.routers.ccg.tls.certresolver=letsencrypt"
+      - "traefik.http.services.ccg.loadbalancer.server.port=8443"
+      - "traefik.http.routers.ccg-http.rule=Host(`ccg.toolvn.io.vn`)"
+      - "traefik.http.routers.ccg-http.entrypoints=http"
+      - "traefik.http.routers.ccg-http.middlewares=ccg-redirect"
+      - "traefik.http.middlewares.ccg-redirect.redirectscheme.scheme=https"
+      - "traefik.http.middlewares.ccg-redirect.redirectscheme.permanent=true"
+
+networks:
+  coolify:
+    external: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "cc-gateway",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-gateway",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "better-sqlite3": "^11.5.0",
         "https-proxy-agent": "^9.0.0",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^22.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
@@ -460,6 +462,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -479,6 +491,87 @@
         "node": ">= 20"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -494,6 +587,48 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/esbuild": {
@@ -538,6 +673,27 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -566,6 +722,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
@@ -579,11 +741,163 @@
         "node": ">= 20"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+      "integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -593,6 +907,129 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsx": {
@@ -615,6 +1052,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -635,6 +1084,18 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,16 @@
     "dev": "tsx watch src/index.ts",
     "generate-token": "tsx src/scripts/generate-token.ts",
     "generate-identity": "tsx src/scripts/generate-identity.ts",
+    "add-user": "tsx src/scripts/add-user.ts",
     "test": "tsx tests/rewriter.test.ts"
   },
   "dependencies": {
+    "better-sqlite3": "^11.5.0",
     "https-proxy-agent": "^9.0.0",
     "yaml": "^2.7.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "tsx watch src/index.ts",
     "generate-token": "tsx src/scripts/generate-token.ts",
     "generate-identity": "tsx src/scripts/generate-identity.ts",
-    "add-user": "tsx src/scripts/add-user.ts",
+    "add-user": "node dist/scripts/add-user.js",
+    "add-user:dev": "tsx src/scripts/add-user.ts",
     "test": "tsx tests/rewriter.test.ts"
   },
   "dependencies": {

--- a/scripts/add-client.sh
+++ b/scripts/add-client.sh
@@ -31,7 +31,7 @@ with open('$CONFIG', 'w') as f:
     echo "  - name: ${CLIENT_NAME}"
     echo "    token: ${CLIENT_TOKEN}"
   }
-  echo "✓ Token added to config.yaml (restart gateway to pick up)"
+  echo "✓ Token added to config.yaml (gateway will hot-reload within ~2s)"
 fi
 
 # Generate the launcher script

--- a/scripts/gen-config.sh
+++ b/scripts/gen-config.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Generate config.yaml for CC Gateway from existing Claude Code OAuth login.
+#
+# Usage:
+#   bash scripts/gen-config.sh                              # print to stdout
+#   bash scripts/gen-config.sh > config.yaml                # save to file
+#   bash scripts/gen-config.sh --client whiletrue0x         # set seed client name
+#   bash scripts/gen-config.sh --out /path/to/config.yaml   # write directly
+#
+# Server use (Coolify host):
+#   bash scripts/gen-config.sh --out /data/coolify/applications/<id>/config.yaml \
+#     && docker restart <container_id>
+set -e
+
+CLIENT_NAME="whiletrue0x"
+OUT_FILE=""
+DEVICE_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --client) CLIENT_NAME="$2"; shift 2 ;;
+    --out)    OUT_FILE="$2";    shift 2 ;;
+    --device) DEVICE_ID="$2";   shift 2 ;;
+    -h|--help)
+      sed -n '2,11p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$DEVICE_ID" ]] && DEVICE_ID=$(openssl rand -hex 32)
+CLIENT_TOKEN=$(openssl rand -hex 32)
+
+# Extract OAuth from macOS Keychain or Linux credentials file
+CREDS=$(security find-generic-password -a "$USER" -s "Claude Code-credentials" -w 2>/dev/null || true)
+if [[ -z "$CREDS" ]]; then
+  for f in "$HOME/.claude/.credentials.json" "$HOME/.config/claude/.credentials.json"; do
+    if [[ -f "$f" ]]; then CREDS=$(cat "$f"); break; fi
+  done
+fi
+if [[ -z "$CREDS" ]]; then
+  echo "Error: No Claude Code OAuth credentials found." >&2
+  echo "Run 'claude' first to login, then re-run this script." >&2
+  exit 1
+fi
+
+eval "$(echo "$CREDS" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)['claudeAiOauth']
+print(f'ACCESS_TOKEN=\"{d[\"accessToken\"]}\"')
+print(f'REFRESH_TOKEN=\"{d[\"refreshToken\"]}\"')
+print(f'EXPIRES_AT={d.get(\"expiresAt\", 0)}')
+")"
+
+if [[ -z "$REFRESH_TOKEN" ]]; then
+  echo "Error: Could not extract refresh_token from credentials." >&2
+  exit 1
+fi
+
+NODE_VER=$(node -v 2>/dev/null || echo "v22.0.0")
+OS_VER=$(uname -sr)
+
+read -r -d '' CONFIG_BODY <<YAML || true
+server:
+  port: 8443
+
+upstream:
+  url: https://api.anthropic.com
+
+oauth:
+  access_token: "${ACCESS_TOKEN}"
+  refresh_token: "${REFRESH_TOKEN}"
+  expires_at: ${EXPIRES_AT}
+
+auth:
+  tokens:
+    - name: ${CLIENT_NAME}
+      token: ${CLIENT_TOKEN}
+
+identity:
+  device_id: "${DEVICE_ID}"
+  email: "user@example.com"
+
+env:
+  platform: darwin
+  platform_raw: darwin
+  arch: arm64
+  node_version: ${NODE_VER}
+  terminal: iTerm2.app
+  package_managers: npm,pnpm
+  runtimes: node
+  is_running_with_bun: false
+  is_ci: false
+  is_claude_ai_auth: true
+  version: "2.1.81"
+  version_base: "2.1.81"
+  build_time: "2026-03-20T21:26:18Z"
+  deployment_environment: unknown-darwin
+  vcs: git
+
+prompt_env:
+  platform: darwin
+  shell: zsh
+  os_version: "${OS_VER}"
+  working_dir: /Users/jack/projects
+
+process:
+  constrained_memory: 34359738368
+  rss_range: [300000000, 500000000]
+  heap_total_range: [40000000, 80000000]
+  heap_used_range: [100000000, 200000000]
+
+logging:
+  level: info
+  audit: true
+
+db:
+  path: /app/data/ccg.db
+YAML
+
+if [[ -n "$OUT_FILE" ]]; then
+  mkdir -p "$(dirname "$OUT_FILE")"
+  printf '%s\n' "$CONFIG_BODY" > "$OUT_FILE"
+  chmod 600 "$OUT_FILE"
+  echo "✓ Wrote $OUT_FILE" >&2
+  echo "  seed client: ${CLIENT_NAME}" >&2
+  echo "  client token: ${CLIENT_TOKEN}" >&2
+  echo "  device_id: ${DEVICE_ID:0:8}..." >&2
+else
+  printf '%s\n' "$CONFIG_BODY"
+fi

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -22,13 +22,15 @@ export function authenticate(req: IncomingMessage): string | null {
     if (entry) return entry.name
   }
 
-  // Fallback: Bearer token in Authorization or Proxy-Authorization
+  // Bearer token in Authorization or Proxy-Authorization
   const authHeader = req.headers['proxy-authorization'] || req.headers['authorization']
-  if (!authHeader || typeof authHeader !== 'string') return null
+  if (authHeader && typeof authHeader === 'string') {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i)
+    if (match) {
+      const entry = tokenMap.get(match[1])
+      if (entry) return entry.name
+    }
+  }
 
-  const match = authHeader.match(/^Bearer\s+(.+)$/i)
-  if (!match) return null
-
-  const entry = tokenMap.get(match[1])
-  return entry?.name ?? null
+  return null
 }

--- a/src/bootstrap-config.ts
+++ b/src/bootstrap-config.ts
@@ -1,0 +1,163 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { randomBytes } from 'crypto'
+import { log } from './logger.js'
+
+interface ClaudeCredentials {
+  accessToken?: string
+  refreshToken?: string
+  expiresAt?: number
+}
+
+function readCredentialsFile(path: string): ClaudeCredentials | null {
+  if (!existsSync(path)) return null
+  try {
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw)
+    const c = parsed.claudeAiOauth || parsed
+    if (typeof c.refreshToken !== 'string') return null
+    return {
+      accessToken: typeof c.accessToken === 'string' ? c.accessToken : undefined,
+      refreshToken: c.refreshToken,
+      expiresAt: typeof c.expiresAt === 'number' ? c.expiresAt : undefined,
+    }
+  } catch (err) {
+    log('warn', `Failed to read credentials from ${path}: ${err instanceof Error ? err.message : err}`)
+    return null
+  }
+}
+
+function gatherSeedCredentials(): ClaudeCredentials | null {
+  // 1. File path (explicit env)
+  const credPath = process.env.CCG_CREDENTIALS_PATH
+  if (credPath) {
+    const fromFile = readCredentialsFile(credPath)
+    if (fromFile) return fromFile
+    log('warn', `CCG_CREDENTIALS_PATH set but file unreadable or missing required fields: ${credPath}`)
+  }
+
+  // 2. Common default file locations (when user mounts credentials.json into container)
+  for (const p of ['/app/data/claude-credentials.json', '/run/secrets/claude-credentials.json']) {
+    const fromFile = readCredentialsFile(p)
+    if (fromFile) return fromFile
+  }
+
+  // 3. Env vars
+  if (process.env.CCG_REFRESH_TOKEN) {
+    return {
+      refreshToken: process.env.CCG_REFRESH_TOKEN,
+      accessToken: process.env.CCG_ACCESS_TOKEN || undefined,
+      expiresAt: process.env.CCG_EXPIRES_AT ? Number(process.env.CCG_EXPIRES_AT) : undefined,
+    }
+  }
+
+  return null
+}
+
+function buildConfigYaml(creds: ClaudeCredentials, opts: {
+  clientName: string
+  clientToken: string
+  deviceId: string
+  email: string
+  dbPath: string
+}): string {
+  const { clientName, clientToken, deviceId, email, dbPath } = opts
+  return `server:
+  port: 8443
+
+upstream:
+  url: https://api.anthropic.com
+
+oauth:
+  access_token: "${creds.accessToken || ''}"
+  refresh_token: "${creds.refreshToken}"
+  expires_at: ${creds.expiresAt || 0}
+
+auth:
+  tokens:
+    - name: ${clientName}
+      token: ${clientToken}
+
+identity:
+  device_id: "${deviceId}"
+  email: "${email}"
+
+env:
+  platform: darwin
+  platform_raw: darwin
+  arch: arm64
+  node_version: v22.0.0
+  terminal: iTerm2.app
+  package_managers: npm,pnpm
+  runtimes: node
+  is_running_with_bun: false
+  is_ci: false
+  is_claude_ai_auth: true
+  version: "2.1.81"
+  version_base: "2.1.81"
+  build_time: "2026-03-20T21:26:18Z"
+  deployment_environment: unknown-darwin
+  vcs: git
+
+prompt_env:
+  platform: darwin
+  shell: zsh
+  os_version: "Darwin 24.4.0"
+  working_dir: /Users/jack/projects
+
+process:
+  constrained_memory: 34359738368
+  rss_range: [300000000, 500000000]
+  heap_total_range: [40000000, 80000000]
+  heap_used_range: [100000000, 200000000]
+
+logging:
+  level: info
+  audit: true
+
+db:
+  path: ${dbPath}
+`
+}
+
+/**
+ * Ensure a config file exists at the given path. If missing, attempt to
+ * auto-generate one from environment / mounted credentials. Returns true if
+ * a config now exists at the path (whether it was already there or just
+ * created). Returns false (and logs why) if bootstrap was needed but failed.
+ */
+export function bootstrapConfigIfMissing(configPath: string): boolean {
+  const absPath = resolve(configPath)
+  if (existsSync(absPath)) return true
+
+  log('info', `No config found at ${absPath} — attempting auto-bootstrap`)
+
+  const creds = gatherSeedCredentials()
+  if (!creds || !creds.refreshToken) {
+    log('error', 'Cannot bootstrap config: no OAuth credentials available.')
+    log('error', '  Set CCG_REFRESH_TOKEN env var, or mount a credentials.json at')
+    log('error', '  CCG_CREDENTIALS_PATH (or /app/data/claude-credentials.json).')
+    return false
+  }
+
+  const dbPath = resolve(dirname(absPath), 'ccg.db')
+  const yaml = buildConfigYaml(creds, {
+    clientName: process.env.CCG_SEED_CLIENT_NAME || 'seed',
+    clientToken: process.env.CCG_SEED_CLIENT_TOKEN || randomBytes(32).toString('hex'),
+    deviceId: process.env.CCG_DEVICE_ID || randomBytes(32).toString('hex'),
+    email: process.env.CCG_EMAIL || 'user@example.com',
+    dbPath,
+  })
+
+  mkdirSync(dirname(absPath), { recursive: true })
+  writeFileSync(absPath, yaml, { encoding: 'utf-8' })
+  try {
+    chmodSync(absPath, 0o600)
+  } catch {
+    // chmod may fail on some mounted filesystems — non-fatal
+  }
+
+  log('info', `Generated ${absPath} (seed client + fresh device_id)`)
+  log('info', '  Edit identity/env/prompt_env if you need a specific fingerprint.')
+  return true
+}

--- a/src/bootstrap-config.ts
+++ b/src/bootstrap-config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs'
 import { dirname, resolve } from 'path'
 import { randomBytes } from 'crypto'
+import { parseDocument, YAMLMap } from 'yaml'
 import { log } from './logger.js'
 
 interface ClaudeCredentials {
@@ -160,4 +161,70 @@ export function bootstrapConfigIfMissing(configPath: string): boolean {
   log('info', `Generated ${absPath} (seed client + fresh device_id)`)
   log('info', '  Edit identity/env/prompt_env if you need a specific fingerprint.')
   return true
+}
+
+/**
+ * Persist a refreshed OAuth token bundle into config.yaml's `oauth:` section.
+ * Round-trips through parseDocument so user edits / comments are preserved.
+ */
+export function updateConfigOAuth(
+  configPath: string,
+  next: { accessToken: string; refreshToken: string; expiresAt: number },
+): void {
+  const absPath = resolve(configPath)
+  if (!existsSync(absPath)) {
+    log('warn', `updateConfigOAuth: ${absPath} does not exist, skipping persist`)
+    return
+  }
+  try {
+    const raw = readFileSync(absPath, 'utf-8')
+    const doc = parseDocument(raw)
+    let oauth = doc.getIn(['oauth'], true) as YAMLMap | undefined
+    if (!oauth) {
+      oauth = new YAMLMap()
+      doc.set('oauth', oauth)
+    }
+    oauth.set('access_token', next.accessToken)
+    oauth.set('refresh_token', next.refreshToken)
+    oauth.set('expires_at', next.expiresAt)
+    writeFileSync(absPath, doc.toString(), 'utf-8')
+  } catch (err) {
+    log('error', `updateConfigOAuth failed: ${err instanceof Error ? err.message : err}`)
+  }
+}
+
+/**
+ * If a mounted credentials.json has a refresh token that differs from the one
+ * already in config.yaml, copy it across before the gateway boots. This handles
+ * the case where the host re-logged in to Claude and rotated the refresh token.
+ *
+ * Only syncs when the credentials file is plausibly newer (different token).
+ * No-op if no credentials file is mounted, or tokens already match.
+ */
+export function syncOAuthFromCredentialsIfChanged(configPath: string): void {
+  const absPath = resolve(configPath)
+  if (!existsSync(absPath)) return
+
+  const creds = gatherSeedCredentials()
+  if (!creds || !creds.refreshToken) return
+
+  let currentRefresh: string | undefined
+  try {
+    const raw = readFileSync(absPath, 'utf-8')
+    const doc = parseDocument(raw)
+    const oauth = doc.getIn(['oauth'], true) as YAMLMap | undefined
+    const rt = oauth?.get('refresh_token')
+    if (typeof rt === 'string') currentRefresh = rt
+  } catch {
+    return
+  }
+
+  if (currentRefresh && currentRefresh === creds.refreshToken) return
+
+  log('info', 'Mounted credentials have a different refresh_token — syncing into config.yaml')
+  updateConfigOAuth(absPath, {
+    accessToken: creds.accessToken || '',
+    refreshToken: creds.refreshToken,
+    expiresAt: creds.expiresAt || 0,
+  })
 }

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -11,7 +11,11 @@ export interface ClientEntry {
 const NAME_RE = /^[a-zA-Z0-9_.-]{1,64}$/
 
 function configPath(): string {
-  return resolve(process.argv[2] || 'config.yaml')
+  return resolve(
+    process.argv[2] ||
+    process.env.CCG_CONFIG_PATH ||
+    '/app/data/config.yaml',
+  )
 }
 
 function loadDoc(path: string) {

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,0 +1,216 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+import { randomBytes } from 'crypto'
+import { parseDocument, YAMLSeq, YAMLMap } from 'yaml'
+
+export interface ClientEntry {
+  name: string
+  token: string
+}
+
+const NAME_RE = /^[a-zA-Z0-9_.-]{1,64}$/
+
+function configPath(): string {
+  return resolve(process.argv[2] || 'config.yaml')
+}
+
+function loadDoc(path: string) {
+  const raw = readFileSync(path, 'utf-8')
+  return parseDocument(raw)
+}
+
+function getTokensSeq(doc: ReturnType<typeof parseDocument>): YAMLSeq {
+  const auth = doc.getIn(['auth'], true) as YAMLMap | undefined
+  if (!auth) throw new Error('config: auth section missing')
+  let tokens = auth.get('tokens', true) as YAMLSeq | undefined
+  if (!tokens) {
+    tokens = new YAMLSeq()
+    auth.set('tokens', tokens)
+  }
+  return tokens
+}
+
+export function listClients(): ClientEntry[] {
+  const doc = loadDoc(configPath())
+  const tokens = getTokensSeq(doc)
+  const out: ClientEntry[] = []
+  for (const item of tokens.items) {
+    if (item instanceof YAMLMap) {
+      const name = item.get('name')
+      const token = item.get('token')
+      if (typeof name === 'string' && typeof token === 'string') {
+        out.push({ name, token })
+      }
+    }
+  }
+  return out
+}
+
+export function addClient(name: string): ClientEntry {
+  if (!NAME_RE.test(name)) {
+    throw new Error('client name must be 1-64 chars, [a-zA-Z0-9_.-]')
+  }
+  const path = configPath()
+  const doc = loadDoc(path)
+  const tokens = getTokensSeq(doc)
+
+  for (const item of tokens.items) {
+    if (item instanceof YAMLMap && item.get('name') === name) {
+      throw new Error(`client "${name}" already exists`)
+    }
+  }
+
+  const token = randomBytes(32).toString('hex')
+  const entry = new YAMLMap()
+  entry.set('name', name)
+  entry.set('token', token)
+  tokens.add(entry)
+
+  writeFileSync(path, doc.toString(), 'utf-8')
+  return { name, token }
+}
+
+export function removeClient(name: string): boolean {
+  const path = configPath()
+  const doc = loadDoc(path)
+  const tokens = getTokensSeq(doc)
+
+  let removedAt = -1
+  for (let i = 0; i < tokens.items.length; i++) {
+    const item = tokens.items[i]
+    if (item instanceof YAMLMap && item.get('name') === name) {
+      removedAt = i
+      break
+    }
+  }
+  if (removedAt === -1) return false
+
+  tokens.delete(removedAt)
+  if (tokens.items.length === 0) {
+    throw new Error('cannot remove the last client — at least one token must remain')
+  }
+  writeFileSync(path, doc.toString(), 'utf-8')
+  return true
+}
+
+export interface LauncherOptions {
+  name: string
+  token: string
+  gatewayAddr: string  // e.g. "ccg.example.com" or "host:port"
+  scheme: 'http' | 'https'
+}
+
+export function buildLauncherScript(opts: LauncherOptions): string {
+  const tlsBypass = opts.scheme === 'https' ? '\n# Accept self-signed TLS cert from gateway\nexport NODE_TLS_REJECT_UNAUTHORIZED=0\n' : ''
+  return `#!/bin/bash
+# CC Gateway Client Launcher — ${opts.name}
+#
+# Usage:
+#   ./cc-${opts.name}                    Start Claude Code through gateway
+#   ./cc-${opts.name} --print "hello"    Single-shot mode
+#   ./cc-${opts.name} install            Install as 'ccg' command system-wide
+#   ./cc-${opts.name} uninstall          Remove 'ccg' and restore native claude
+#   ./cc-${opts.name} native             Run native claude (bypass gateway)
+
+GATEWAY_URL="${opts.scheme}://${opts.gatewayAddr}"
+CLIENT_TOKEN="${opts.token}"
+${tlsBypass}
+INSTALL_PATH="/usr/local/bin/ccg"
+SELF_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+case "$SHELL" in
+  */zsh)  RC_FILE="\${ZDOTDIR:-$HOME}/.zshrc" ;;
+  */bash) RC_FILE="$HOME/.bashrc" ;;
+  */fish) RC_FILE="\${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish" ;;
+  *)      RC_FILE="$HOME/.profile" ;;
+esac
+ALIAS_TAG="# cc-gateway alias"
+
+case "$1" in
+  install)
+    cp "$0" "$INSTALL_PATH" 2>/dev/null || sudo cp "$0" "$INSTALL_PATH"
+    chmod +x "$INSTALL_PATH"
+    echo "Installed as 'ccg'."
+    exit 0
+    ;;
+  uninstall)
+    rm "$INSTALL_PATH" 2>/dev/null || sudo rm "$INSTALL_PATH"
+    if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
+      sed -i.bak "/$ALIAS_TAG/d" "$RC_FILE"
+      rm -f "\${RC_FILE}.bak"
+    fi
+    echo "Removed."
+    exit 0
+    ;;
+  hijack)
+    if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
+      echo "Already active. Run 'ccg release' to undo."
+    else
+      if [[ "$SHELL" == */fish ]]; then
+        echo "alias claude 'ccg' $ALIAS_TAG" >> "$RC_FILE"
+      else
+        echo "alias claude='ccg' $ALIAS_TAG" >> "$RC_FILE"
+      fi
+      echo "Done. Reopen terminal or: source $RC_FILE"
+    fi
+    exit 0
+    ;;
+  release)
+    if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
+      sed -i.bak "/$ALIAS_TAG/d" "$RC_FILE"
+      rm -f "\${RC_FILE}.bak"
+      unalias claude 2>/dev/null
+      echo "Done."
+    else
+      echo "Nothing to undo."
+    fi
+    exit 0
+    ;;
+  native)
+    shift
+    exec command claude "$@"
+    ;;
+  status)
+    echo "Gateway:  $GATEWAY_URL"
+    if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
+      echo "Hijack:   ON"
+    else
+      echo "Hijack:   OFF"
+    fi
+    HEALTH=$(curl -sk --max-time 3 "\${GATEWAY_URL}/_health" 2>/dev/null)
+    [[ -n "$HEALTH" ]] && echo "Health:   OK" || echo "Health:   UNREACHABLE"
+    exit 0
+    ;;
+  help|--help|-h)
+    echo "ccg — Claude Code Gateway Client"
+    echo ""
+    echo "  ccg                    Start Claude Code through gateway"
+    echo "  ccg install            Install as 'ccg' system command"
+    echo "  ccg uninstall          Remove 'ccg'"
+    echo "  ccg hijack             Make 'claude' go through gateway"
+    echo "  ccg release            Restore native 'claude'"
+    echo "  ccg native [args]      Run native claude once"
+    echo "  ccg status             Show gateway status"
+    exit 0
+    ;;
+esac
+
+if ! command -v claude &>/dev/null; then
+  echo "Error: 'claude' not found. Install Claude Code first:"
+  echo "  npm install -g @anthropic-ai/claude-code"
+  exit 1
+fi
+
+export ANTHROPIC_API_KEY="$CLIENT_TOKEN"
+export ANTHROPIC_BASE_URL="$GATEWAY_URL"
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+export CLAUDE_CODE_ATTRIBUTION_HEADER=false
+
+HEALTH=$(curl -sk --max-time 3 "\${GATEWAY_URL}/_health" 2>/dev/null)
+if [[ -z "$HEALTH" ]]; then
+  echo "Warning: Gateway at \${GATEWAY_URL} is not reachable."
+  echo ""
+fi
+
+exec claude "$@"
+`
+}

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -105,22 +105,25 @@ export interface LauncherOptions {
 }
 
 export function buildLauncherScript(opts: LauncherOptions): string {
-  const tlsBypass = opts.scheme === 'https' ? '\n# Accept self-signed TLS cert from gateway\nexport NODE_TLS_REJECT_UNAUTHORIZED=0\n' : ''
+  const tlsBypass =
+    opts.scheme === 'https'
+      ? '\n# Accept self-signed TLS cert from gateway\nexport NODE_TLS_REJECT_UNAUTHORIZED=0\n'
+      : ''
   return `#!/bin/bash
-# CC Gateway Client Launcher — ${opts.name}
+# CC Gateway Client Launcher
 #
 # Usage:
 #   ./cc-${opts.name}                    Start Claude Code through gateway
 #   ./cc-${opts.name} --print "hello"    Single-shot mode
 #   ./cc-${opts.name} install            Install as 'ccg' command system-wide
 #   ./cc-${opts.name} uninstall          Remove 'ccg' and restore native claude
-#   ./cc-${opts.name} native             Run native claude (bypass gateway)
-
+#   ./cc-${opts.name} native             Run native claude (bypass gateway, one-time)
 GATEWAY_URL="${opts.scheme}://${opts.gatewayAddr}"
 CLIENT_TOKEN="${opts.token}"
 ${tlsBypass}
 INSTALL_PATH="/usr/local/bin/ccg"
 SELF_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+# Detect shell RC file
 case "$SHELL" in
   */zsh)  RC_FILE="\${ZDOTDIR:-$HOME}/.zshrc" ;;
   */bash) RC_FILE="$HOME/.bashrc" ;;
@@ -129,22 +132,32 @@ case "$SHELL" in
 esac
 ALIAS_TAG="# cc-gateway alias"
 
+# ── Subcommands ──
+
 case "$1" in
   install)
     cp "$0" "$INSTALL_PATH" 2>/dev/null || sudo cp "$0" "$INSTALL_PATH"
     chmod +x "$INSTALL_PATH"
     echo "Installed as 'ccg'."
+    echo ""
+    echo "  ccg              Start Claude Code through gateway"
+    echo "  ccg hijack       Make 'claude' also go through gateway"
+    echo "  ccg release      Restore 'claude' to native"
+    echo "  ccg status       Show gateway connection status"
+    echo "  ccg help         Show this help"
     exit 0
     ;;
+
   uninstall)
     rm "$INSTALL_PATH" 2>/dev/null || sudo rm "$INSTALL_PATH"
     if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
       sed -i.bak "/$ALIAS_TAG/d" "$RC_FILE"
       rm -f "\${RC_FILE}.bak"
     fi
-    echo "Removed."
+    echo "Removed. Native 'claude' restored."
     exit 0
     ;;
+
   hijack)
     if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
       echo "Already active. Run 'ccg release' to undo."
@@ -154,67 +167,96 @@ case "$1" in
       else
         echo "alias claude='ccg' $ALIAS_TAG" >> "$RC_FILE"
       fi
-      echo "Done. Reopen terminal or: source $RC_FILE"
+      echo "Done. 'claude' now goes through gateway."
+      echo "  New terminals: automatic."
+      echo "  This terminal: reopen or run: source $RC_FILE"
+      echo "  Undo anytime: ccg release"
     fi
     exit 0
     ;;
+
   release)
     if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
       sed -i.bak "/$ALIAS_TAG/d" "$RC_FILE"
       rm -f "\${RC_FILE}.bak"
+      # Unalias in current shell
       unalias claude 2>/dev/null
-      echo "Done."
+      echo "Done. 'claude' is back to native."
     else
-      echo "Nothing to undo."
+      echo "Nothing to undo — 'claude' is already native."
     fi
     exit 0
     ;;
+
   native)
     shift
     exec command claude "$@"
     ;;
+
   status)
     echo "Gateway:  $GATEWAY_URL"
     if grep -q "$ALIAS_TAG" "$RC_FILE" 2>/dev/null; then
-      echo "Hijack:   ON"
+      echo "Hijack:   ON  (claude → gateway)"
     else
-      echo "Hijack:   OFF"
+      echo "Hijack:   OFF (claude = native)"
     fi
     HEALTH=$(curl -sk --max-time 3 "\${GATEWAY_URL}/_health" 2>/dev/null)
-    [[ -n "$HEALTH" ]] && echo "Health:   OK" || echo "Health:   UNREACHABLE"
+    if [[ -n "$HEALTH" ]]; then
+      echo "Health:   OK"
+    else
+      echo "Health:   UNREACHABLE"
+    fi
     exit 0
     ;;
+
   help|--help|-h)
     echo "ccg — Claude Code Gateway Client"
     echo ""
+    echo "Usage:"
     echo "  ccg                    Start Claude Code through gateway"
+    echo "  ccg [claude args]      Pass any arguments to Claude Code"
+    echo "  ccg --print \\"hi\\"       Single-shot mode"
+    echo ""
+    echo "Setup:"
     echo "  ccg install            Install as 'ccg' system command"
-    echo "  ccg uninstall          Remove 'ccg'"
+    echo "  ccg uninstall          Remove 'ccg' and clean up"
+    echo ""
+    echo "Routing:"
     echo "  ccg hijack             Make 'claude' go through gateway"
-    echo "  ccg release            Restore native 'claude'"
-    echo "  ccg native [args]      Run native claude once"
-    echo "  ccg status             Show gateway status"
+    echo "  ccg release            Restore 'claude' to native"
+    echo "  ccg native [args]      Run native claude once (bypass gateway)"
+    echo ""
+    echo "Info:"
+    echo "  ccg status             Show gateway and hijack status"
+    echo "  ccg help               Show this help"
     exit 0
     ;;
 esac
 
+# ── Main: launch through gateway ──
+
+# Check claude is installed
 if ! command -v claude &>/dev/null; then
   echo "Error: 'claude' not found. Install Claude Code first:"
   echo "  npm install -g @anthropic-ai/claude-code"
   exit 1
 fi
 
+# Set env vars for this process only — nothing is written to disk
 export ANTHROPIC_API_KEY="$CLIENT_TOKEN"
 export ANTHROPIC_BASE_URL="$GATEWAY_URL"
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
 export CLAUDE_CODE_ATTRIBUTION_HEADER=false
 
+# Check gateway is reachable
 HEALTH=$(curl -sk --max-time 3 "\${GATEWAY_URL}/_health" 2>/dev/null)
 if [[ -z "$HEALTH" ]]; then
   echo "Warning: Gateway at \${GATEWAY_URL} is not reachable."
+  echo "Make sure the gateway is running."
   echo ""
 fi
 
+# Pass all arguments through to claude
 exec claude "$@"
 `
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,9 @@ export type Config = {
     level: 'debug' | 'info' | 'warn' | 'error'
     audit: boolean
   }
+  db?: {
+    path: string
+  }
 }
 
 export function loadConfig(configPath?: string): Config {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -321,11 +321,13 @@ export function renderDashboard(): string {
   const renderTopStats = (data) => {
     const t = data.totals;
     const errRate = t.total ? ((t.errors / t.total) * 100).toFixed(1) : '0.0';
-    const totalTokens = (t.inputTokens || 0) + (t.outputTokens || 0);
     const html = [
       ['Total requests', fmtNum(t.total)],
       ['Total cost', fmtCost(t.costUsd)],
-      ['Total tokens', fmtTokens(totalTokens)],
+      ['Input tokens', fmtTokens(t.inputTokens)],
+      ['Output tokens', fmtTokens(t.outputTokens)],
+      ['Cache read', fmtTokens(t.cacheReadTokens)],
+      ['Cache write', fmtTokens(t.cacheCreationTokens)],
       ['Active clients', fmtNum(data.clients.length)],
       ['Errors', fmtNum(t.errors) + ' (' + errRate + '%)'],
       ['Uptime', fmtUptime(data.uptimeMs)],
@@ -404,11 +406,12 @@ export function renderDashboard(): string {
     }
     const rows = data.clients.map(c => {
       const s = statusClass(c.byStatus);
-      const totalTokens = (c.inputTokens || 0) + (c.outputTokens || 0);
       return \`<tr>
         <td><strong>\${c.name}</strong></td>
         <td class="num">\${fmtNum(c.total)}</td>
-        <td class="num" title="input \${fmtNum(c.inputTokens)} · output \${fmtNum(c.outputTokens)} · cache_r \${fmtNum(c.cacheReadTokens)} · cache_w \${fmtNum(c.cacheCreationTokens)}">\${fmtTokens(totalTokens)}</td>
+        <td class="num" title="\${fmtNum(c.inputTokens)} tokens">\${fmtTokens(c.inputTokens)}</td>
+        <td class="num" title="\${fmtNum(c.outputTokens)} tokens">\${fmtTokens(c.outputTokens)}</td>
+        <td class="num" title="cache read \${fmtNum(c.cacheReadTokens)} · cache write \${fmtNum(c.cacheCreationTokens)}">\${fmtTokens((c.cacheReadTokens || 0) + (c.cacheCreationTokens || 0))}</td>
         <td class="num"><strong>\${fmtCost(c.costUsd)}</strong></td>
         <td><span class="pill ok">\${s.ok}</span> <span class="pill warn">\${s.warn}</span> <span class="pill err">\${s.err}</span></td>
         <td class="num">\${c.avgDurationMs}ms</td>
@@ -420,7 +423,9 @@ export function renderDashboard(): string {
         <thead><tr>
           <th>Client</th>
           <th class="num">Calls</th>
-          <th class="num">Tokens</th>
+          <th class="num" title="Input tokens">Input</th>
+          <th class="num" title="Output tokens">Output</th>
+          <th class="num" title="Cache read + cache write tokens">Cache</th>
           <th class="num">Cost</th>
           <th>2xx / 4xx / 5xx</th>
           <th class="num">Avg</th>
@@ -437,27 +442,33 @@ export function renderDashboard(): string {
     }
     const rows = data.recent.map(r => {
       const cls = r.status >= 500 ? 'err' : r.status >= 400 ? 'warn' : 'ok';
-      const tt = (r.inputTokens || 0) + (r.outputTokens || 0);
-      const tokenLabel = tt
-        ? fmtTokens(tt) + ' (' + fmtTokens(r.inputTokens) + '↓ ' + fmtTokens(r.outputTokens) + '↑)'
-        : '—';
+      const hasUsage = (r.inputTokens || r.outputTokens || r.cacheReadTokens || r.cacheCreationTokens);
       return \`<tr>
         <td class="ago">\${fmtAgo(r.ts)}</td>
         <td>\${r.client}</td>
-        <td>\${r.method}</td>
-        <td class="path" title="\${r.path}">\${r.path}</td>
+        <td><span class="meta">\${shortModel(r.model)}</span></td>
+        <td class="path" title="\${r.method} \${r.path}">\${r.path}</td>
         <td><span class="pill \${cls}">\${r.status}</span></td>
         <td class="num">\${r.durationMs}ms</td>
-        <td class="num" title="model: \${r.model || '—'}">\${tokenLabel}</td>
+        <td class="num" title="\${fmtNum(r.inputTokens)} input tokens">\${hasUsage ? fmtTokens(r.inputTokens) : '—'}</td>
+        <td class="num" title="\${fmtNum(r.outputTokens)} output tokens">\${hasUsage ? fmtTokens(r.outputTokens) : '—'}</td>
+        <td class="num" title="cache read \${fmtNum(r.cacheReadTokens)} · cache write \${fmtNum(r.cacheCreationTokens)}">\${hasUsage ? fmtTokens((r.cacheReadTokens || 0) + (r.cacheCreationTokens || 0)) : '—'}</td>
         <td class="num">\${r.costUsd ? fmtCost(r.costUsd) : '—'}</td>
       </tr>\`;
     }).join('');
     document.getElementById('recentTable').innerHTML = \`
       <table>
         <thead><tr>
-          <th>When</th><th>Client</th><th>Method</th><th>Path</th>
-          <th>Status</th><th class="num">Duration</th>
-          <th class="num">Tokens</th><th class="num">Cost</th>
+          <th>When</th>
+          <th>Client</th>
+          <th>Model</th>
+          <th>Path</th>
+          <th>Status</th>
+          <th class="num">Duration</th>
+          <th class="num">Input</th>
+          <th class="num">Output</th>
+          <th class="num">Cache</th>
+          <th class="num">Cost</th>
         </tr></thead>
         <tbody>\${rows}</tbody>
       </table>\`;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,0 +1,477 @@
+export function renderLogin(error?: string): string {
+  const errBlock = error
+    ? `<div class="error">${escapeHtml(error)}</div>`
+    : ''
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>CC Gateway — Login</title>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<style>
+  body {
+    margin: 0; min-height: 100vh;
+    display: flex; align-items: center; justify-content: center;
+    background: #0b0d10; color: #e6edf3;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  }
+  .box {
+    background: #14181d; border: 1px solid #232a33; border-radius: 10px;
+    padding: 32px; width: 360px; max-width: 90vw;
+  }
+  h1 { font-size: 18px; margin: 0 0 6px; }
+  p.sub { color: #8b949e; font-size: 13px; margin: 0 0 22px; }
+  label { display: block; font-size: 12px; color: #8b949e; margin: 14px 0 4px; text-transform: uppercase; letter-spacing: .04em; }
+  input {
+    width: 100%; padding: 10px 12px; box-sizing: border-box;
+    background: #0b0d10; color: #e6edf3;
+    border: 1px solid #232a33; border-radius: 6px;
+    font-size: 14px; font-family: inherit;
+  }
+  input:focus { outline: none; border-color: #58a6ff; }
+  button {
+    margin-top: 22px; width: 100%; padding: 10px;
+    background: #1f6feb; color: white; border: 0; border-radius: 6px;
+    font-size: 14px; font-weight: 500; cursor: pointer;
+  }
+  button:hover { background: #388bfd; }
+  .error { background: rgba(248,81,73,.1); border: 1px solid rgba(248,81,73,.3); color: #f85149; padding: 10px 12px; border-radius: 6px; font-size: 13px; margin-bottom: 8px; }
+</style>
+</head>
+<body>
+  <form class="box" method="post" action="/login">
+    <h1>CC Gateway</h1>
+    <p class="sub">Sign in to access the dashboard</p>
+    ${errBlock}
+    <label for="username">Username</label>
+    <input id="username" name="username" autocomplete="username" autofocus required />
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password" autocomplete="current-password" required />
+    <button type="submit">Sign in</button>
+  </form>
+</body>
+</html>`
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export function renderDashboard(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>CC Gateway — Dashboard</title>
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<style>
+  :root {
+    --bg: #0b0d10;
+    --panel: #14181d;
+    --panel-2: #1b2027;
+    --border: #232a33;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --accent: #58a6ff;
+    --ok: #3fb950;
+    --warn: #d29922;
+    --err: #f85149;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: var(--bg); color: var(--fg);
+    font-size: 14px;
+  }
+  header {
+    padding: 14px 24px; border-bottom: 1px solid var(--border);
+    display: flex; align-items: center; justify-content: space-between;
+    background: var(--panel);
+  }
+  header h1 { font-size: 16px; margin: 0; font-weight: 600; }
+  header .meta { color: var(--muted); font-size: 12px; font-family: var(--mono); }
+  main { padding: 20px 24px; max-width: 1400px; margin: 0 auto; }
+  .grid { display: grid; gap: 16px; }
+  .row { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px,1fr)); gap: 12px; }
+  .card {
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: 8px; padding: 16px;
+  }
+  .card h2 {
+    margin: 0 0 12px; font-size: 12px; letter-spacing: .04em;
+    text-transform: uppercase; color: var(--muted); font-weight: 600;
+  }
+  .stat .value { font-size: 26px; font-weight: 600; font-family: var(--mono); }
+  .stat .label { font-size: 11px; color: var(--muted); text-transform: uppercase; margin-top: 4px; letter-spacing: .03em; }
+  table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 13px; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+  tr:last-child td { border-bottom: none; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-family: var(--mono); }
+  .pill.ok { background: rgba(63,185,80,.15); color: var(--ok); }
+  .pill.warn { background: rgba(210,153,34,.15); color: var(--warn); }
+  .pill.err { background: rgba(248,81,73,.15); color: var(--err); }
+  .chart { display: flex; align-items: flex-end; gap: 1px; height: 70px; padding-top: 4px; }
+  .bar { flex: 1; background: var(--accent); opacity: .85; border-radius: 1px 1px 0 0; min-height: 1px; }
+  .bar:hover { opacity: 1; }
+  .ago { color: var(--muted); }
+  .path { color: var(--fg); opacity: .9; max-width: 380px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .toolbar { display: flex; align-items: center; gap: 12px; }
+  select, button {
+    background: var(--panel-2); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 6px 10px; font-size: 13px; font-family: inherit;
+    cursor: pointer;
+  }
+  button:hover, select:hover { border-color: var(--accent); }
+  .empty { color: var(--muted); padding: 24px; text-align: center; font-style: italic; }
+  button.primary { background: #1f6feb; border-color: #1f6feb; color: white; }
+  button.primary:hover { background: #388bfd; border-color: #388bfd; }
+  button.danger { background: transparent; color: var(--err); border-color: rgba(248,81,73,.4); }
+  button.danger:hover { background: rgba(248,81,73,.1); border-color: var(--err); }
+  .modal {
+    position: fixed; inset: 0; background: rgba(0,0,0,.6);
+    display: flex; align-items: center; justify-content: center; z-index: 100;
+  }
+  .modal-box {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    padding: 24px; width: 420px; max-width: 92vw;
+  }
+  .modal-box h3 { margin: 0 0 4px; }
+  .modal-box label { display: block; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; margin: 14px 0 4px; }
+  .modal-box input, .modal-box select {
+    width: 100%; padding: 8px 10px; box-sizing: border-box;
+    background: var(--bg); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 6px;
+    font-size: 14px; font-family: inherit;
+  }
+  .modal-box input:focus, .modal-box select:focus { outline: none; border-color: var(--accent); }
+  .error { background: rgba(248,81,73,.1); border: 1px solid rgba(248,81,73,.3); color: var(--err); padding: 8px 10px; border-radius: 6px; font-size: 13px; }
+  .config-info { background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; font-size: 12px; color: var(--muted); font-family: var(--mono); }
+</style>
+</head>
+<body>
+<header>
+  <h1>CC Gateway · Request Dashboard</h1>
+  <div class="toolbar">
+    <span class="meta" id="updated">loading…</span>
+    <select id="rangeSel">
+      <option value="minute">Last 60 min</option>
+      <option value="hour">Last 24 h</option>
+    </select>
+    <button id="refreshBtn">Refresh</button>
+    <form action="/logout" method="post" style="display:inline">
+      <button type="submit">Logout</button>
+    </form>
+  </div>
+</header>
+<main>
+  <div class="grid">
+    <div class="row" id="topStats"></div>
+    <div class="card">
+      <h2>Requests over time (per client)</h2>
+      <div id="charts" class="grid"></div>
+    </div>
+    <div class="card">
+      <h2>
+        Clients
+        <button id="addClientBtn" style="float:right;margin-top:-4px">+ Add client</button>
+      </h2>
+      <div id="clientsConfig" style="margin-bottom:12px"></div>
+      <div id="clientsTable"></div>
+    </div>
+    <div class="card">
+      <h2>Recent requests</h2>
+      <div id="recentTable"></div>
+    </div>
+  </div>
+</main>
+
+<div id="addClientModal" class="modal" style="display:none">
+  <div class="modal-box">
+    <h3>Add client</h3>
+    <p class="meta" style="margin:0 0 16px">Generates a token, appends it to <code>config.yaml</code>, and downloads a launcher script.</p>
+    <label>Client name</label>
+    <input id="cName" placeholder="e.g. vuluu2k" autocomplete="off" />
+    <label>Gateway address</label>
+    <input id="cAddr" placeholder="ccg.example.com" autocomplete="off" />
+    <label>Scheme</label>
+    <select id="cScheme">
+      <option value="https">https</option>
+      <option value="http">http</option>
+    </select>
+    <div id="cError" class="error" style="display:none;margin-top:12px"></div>
+    <div style="display:flex;gap:8px;margin-top:18px;justify-content:flex-end">
+      <button id="cCancel" type="button">Cancel</button>
+      <button id="cSubmit" type="button" class="primary">Create &amp; download</button>
+    </div>
+  </div>
+</div>
+<script>
+(() => {
+  const range = () => document.getElementById('rangeSel').value;
+
+  const fmtNum = (n) => n.toLocaleString();
+  const fmtAgo = (ts) => {
+    const d = Math.max(0, Date.now() - ts);
+    if (d < 1000) return 'just now';
+    if (d < 60_000) return Math.floor(d / 1000) + 's ago';
+    if (d < 3_600_000) return Math.floor(d / 60_000) + 'm ago';
+    if (d < 86_400_000) return Math.floor(d / 3_600_000) + 'h ago';
+    return Math.floor(d / 86_400_000) + 'd ago';
+  };
+  const fmtUptime = (ms) => {
+    const s = Math.floor(ms / 1000);
+    const d = Math.floor(s / 86400);
+    const h = Math.floor((s % 86400) / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    if (d) return d + 'd ' + h + 'h';
+    if (h) return h + 'h ' + m + 'm';
+    return m + 'm';
+  };
+  const statusClass = (status) => {
+    const ok = (status['2xx'] || 0) + (status['3xx'] || 0);
+    const warn = status['4xx'] || 0;
+    const err = status['5xx'] || 0;
+    return { ok, warn, err };
+  };
+
+  const renderTopStats = (data) => {
+    const t = data.totals;
+    const errRate = t.total ? ((t.errors / t.total) * 100).toFixed(1) : '0.0';
+    const html = [
+      ['Total requests', fmtNum(t.total)],
+      ['Active clients', fmtNum(data.clients.length)],
+      ['Errors', fmtNum(t.errors) + ' (' + errRate + '%)'],
+      ['Uptime', fmtUptime(data.uptimeMs)],
+    ].map(([label, value]) => \`
+      <div class="card stat">
+        <div class="value">\${value}</div>
+        <div class="label">\${label}</div>
+      </div>\`).join('');
+    document.getElementById('topStats').innerHTML = html;
+  };
+
+  const renderCharts = (data) => {
+    const series = range() === 'hour' ? data.hourSeries : data.minuteSeries;
+    const unit = range() === 'hour' ? 'h' : 'm';
+    const clients = Object.keys(series);
+    if (!clients.length) {
+      document.getElementById('charts').innerHTML = '<div class="empty">No traffic yet</div>';
+      return;
+    }
+    const max = Math.max(1, ...clients.flatMap(c => series[c].map(b => b.count)));
+    document.getElementById('charts').innerHTML = clients.map(c => {
+      const points = series[c];
+      const total = points.reduce((s, p) => s + p.count, 0);
+      const bars = points.map(p => {
+        const h = Math.round((p.count / max) * 100);
+        return \`<div class="bar" style="height:\${Math.max(1, h)}%" title="\${new Date(p.ts).toLocaleString()} — \${p.count} req"></div>\`;
+      }).join('');
+      return \`
+        <div>
+          <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:4px">
+            <strong>\${c}</strong>
+            <span class="meta">\${total} req · last \${points.length}\${unit}</span>
+          </div>
+          <div class="chart">\${bars}</div>
+        </div>\`;
+    }).join('');
+  };
+
+  const renderClients = (data) => {
+    if (!data.clients.length) {
+      document.getElementById('clientsTable').innerHTML = '<div class="empty">No clients have called yet</div>';
+      return;
+    }
+    const rows = data.clients.map(c => {
+      const s = statusClass(c.byStatus);
+      return \`<tr>
+        <td><strong>\${c.name}</strong></td>
+        <td class="num">\${fmtNum(c.total)}</td>
+        <td><span class="pill ok">\${s.ok} 2xx</span> <span class="pill warn">\${s.warn} 4xx</span> <span class="pill err">\${s.err} 5xx</span></td>
+        <td class="num">\${c.avgDurationMs}ms</td>
+        <td class="ago">\${fmtAgo(c.lastSeen)}</td>
+      </tr>\`;
+    }).join('');
+    document.getElementById('clientsTable').innerHTML = \`
+      <table>
+        <thead><tr>
+          <th>Client</th><th class="num">Total</th><th>Status</th><th class="num">Avg</th><th>Last seen</th>
+        </tr></thead>
+        <tbody>\${rows}</tbody>
+      </table>\`;
+  };
+
+  const renderRecent = (data) => {
+    if (!data.recent.length) {
+      document.getElementById('recentTable').innerHTML = '<div class="empty">No requests yet</div>';
+      return;
+    }
+    const rows = data.recent.map(r => {
+      const cls = r.status >= 500 ? 'err' : r.status >= 400 ? 'warn' : 'ok';
+      return \`<tr>
+        <td class="ago">\${fmtAgo(r.ts)}</td>
+        <td>\${r.client}</td>
+        <td>\${r.method}</td>
+        <td class="path" title="\${r.path}">\${r.path}</td>
+        <td><span class="pill \${cls}">\${r.status}</span></td>
+        <td class="num">\${r.durationMs}ms</td>
+      </tr>\`;
+    }).join('');
+    document.getElementById('recentTable').innerHTML = \`
+      <table>
+        <thead><tr>
+          <th>When</th><th>Client</th><th>Method</th><th>Path</th><th>Status</th><th class="num">Duration</th>
+        </tr></thead>
+        <tbody>\${rows}</tbody>
+      </table>\`;
+  };
+
+  let currentData = null;
+
+  const refresh = async () => {
+    try {
+      const res = await fetch('/_metrics', { cache: 'no-store', credentials: 'same-origin' });
+      if (res.status === 401) {
+        location.href = '/login';
+        return;
+      }
+      if (!res.ok) {
+        document.getElementById('updated').textContent = 'error: ' + res.status;
+        return;
+      }
+      currentData = await res.json();
+      renderTopStats(currentData);
+      renderCharts(currentData);
+      renderClients(currentData);
+      renderRecent(currentData);
+      document.getElementById('updated').textContent = 'updated ' + new Date().toLocaleTimeString();
+    } catch (e) {
+      document.getElementById('updated').textContent = 'fetch error';
+    }
+  };
+
+  document.getElementById('refreshBtn').addEventListener('click', refresh);
+  document.getElementById('rangeSel').addEventListener('change', () => {
+    if (currentData) renderCharts(currentData);
+  });
+
+  // ── Clients management ──
+  const renderClientsConfig = (clients) => {
+    const el = document.getElementById('clientsConfig');
+    if (!clients.length) {
+      el.innerHTML = '<div class="empty">No clients configured</div>';
+      return;
+    }
+    const rows = clients.map(c => \`
+      <tr>
+        <td><strong>\${c.name}</strong></td>
+        <td><code class="config-info">\${c.token_preview}</code></td>
+        <td style="text-align:right">
+          <button class="danger" data-del-client="\${c.name}">Delete</button>
+        </td>
+      </tr>\`).join('');
+    el.innerHTML = \`
+      <table>
+        <thead><tr><th>Configured client</th><th>Token</th><th></th></tr></thead>
+        <tbody>\${rows}</tbody>
+      </table>\`;
+    el.querySelectorAll('[data-del-client]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const name = btn.getAttribute('data-del-client');
+        if (!confirm('Delete client "' + name + '"? This revokes its token immediately.')) return;
+        const res = await fetch('/api/clients/' + encodeURIComponent(name), {
+          method: 'DELETE', credentials: 'same-origin',
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          alert('Failed: ' + (err.error || res.status));
+          return;
+        }
+        loadClients();
+      });
+    });
+  };
+
+  const loadClients = async () => {
+    const res = await fetch('/api/clients', { credentials: 'same-origin' });
+    if (!res.ok) return;
+    const data = await res.json();
+    renderClientsConfig(data.clients || []);
+  };
+
+  const showError = (msg) => {
+    const el = document.getElementById('cError');
+    if (msg) { el.textContent = msg; el.style.display = 'block'; }
+    else { el.style.display = 'none'; }
+  };
+
+  const openModal = () => {
+    document.getElementById('cName').value = '';
+    document.getElementById('cAddr').value = location.host;
+    document.getElementById('cScheme').value = location.protocol === 'http:' ? 'http' : 'https';
+    showError(null);
+    document.getElementById('addClientModal').style.display = 'flex';
+    setTimeout(() => document.getElementById('cName').focus(), 0);
+  };
+  const closeModal = () => { document.getElementById('addClientModal').style.display = 'none'; };
+
+  const submitClient = async () => {
+    const name = document.getElementById('cName').value.trim();
+    const gateway_addr = document.getElementById('cAddr').value.trim();
+    const scheme = document.getElementById('cScheme').value;
+    if (!name) { showError('Name is required'); return; }
+    const submitBtn = document.getElementById('cSubmit');
+    submitBtn.disabled = true;
+    try {
+      const res = await fetch('/api/clients', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, gateway_addr, scheme }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        showError(err.error || 'Request failed: ' + res.status);
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'cc-' + name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      closeModal();
+      loadClients();
+    } finally {
+      submitBtn.disabled = false;
+    }
+  };
+
+  document.getElementById('addClientBtn').addEventListener('click', openModal);
+  document.getElementById('cCancel').addEventListener('click', closeModal);
+  document.getElementById('cSubmit').addEventListener('click', submitClient);
+  document.getElementById('addClientModal').addEventListener('click', (e) => {
+    if (e.target.id === 'addClientModal') closeModal();
+  });
+
+  loadClients();
+  refresh();
+  setInterval(refresh, 5000);
+})();
+</script>
+</body>
+</html>`
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -190,12 +190,17 @@ export function renderDashboard(): string {
 <main>
   <div class="grid">
     <div class="row" id="topStats"></div>
+    <div class="card">
+      <h2>Cost &amp; usage by period</h2>
+      <div id="periodTable"></div>
+    </div>
     <details class="card" id="aboutCard">
       <summary style="cursor:pointer;font-weight:600;font-size:13px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em">
         How to use this dashboard
       </summary>
       <div style="margin-top:12px;font-size:13px;line-height:1.6;color:var(--fg)">
         <p style="margin:0 0 10px"><strong>Stats row</strong> — totals across the gateway's full history (persisted in SQLite): requests, accumulated cost (USD list price), tokens, active clients, errors, uptime.</p>
+        <p style="margin:0 0 10px"><strong>Cost &amp; usage by period</strong> — same totals split by Today / Last 7d / Last 30d / All time so you can track spend trend.</p>
         <p style="margin:0 0 10px"><strong>Requests over time</strong> — per-client traffic. Toggle <em>Last 60 min</em> / <em>Last 24 h</em>.</p>
         <p style="margin:0 0 10px"><strong>By model</strong> — per-model totals: calls, input/output/cache tokens, and cost. Cost uses Anthropic public list prices.</p>
         <p style="margin:0 0 10px"><strong>Clients</strong> — every entry under <code>auth.tokens</code>, with their lifetime calls / tokens / cost. Click <strong>+ Add client</strong> to generate a token, append it to <code>config.yaml</code>, and download a launcher script.</p>
@@ -337,6 +342,39 @@ export function renderDashboard(): string {
         <div class="label">\${label}</div>
       </div>\`).join('');
     document.getElementById('topStats').innerHTML = html;
+  };
+
+  const renderPeriods = (data) => {
+    const t = data.totals;
+    const periods = (data.periods || []).concat([{
+      key: 'all', label: 'All time',
+      total: t.total,
+      inputTokens: t.inputTokens,
+      outputTokens: t.outputTokens,
+      cacheReadTokens: t.cacheReadTokens,
+      cacheCreationTokens: t.cacheCreationTokens,
+      costUsd: t.costUsd,
+    }]);
+    const rows = periods.map(p => \`<tr>
+      <td><strong>\${p.label}</strong></td>
+      <td class="num">\${fmtNum(p.total)}</td>
+      <td class="num" title="\${fmtNum(p.inputTokens)} tokens">\${fmtTokens(p.inputTokens)}</td>
+      <td class="num" title="\${fmtNum(p.outputTokens)} tokens">\${fmtTokens(p.outputTokens)}</td>
+      <td class="num" title="cache read \${fmtNum(p.cacheReadTokens)} · cache write \${fmtNum(p.cacheCreationTokens)}">\${fmtTokens((p.cacheReadTokens || 0) + (p.cacheCreationTokens || 0))}</td>
+      <td class="num"><strong>\${fmtCost(p.costUsd)}</strong></td>
+    </tr>\`).join('');
+    document.getElementById('periodTable').innerHTML = \`
+      <table>
+        <thead><tr>
+          <th>Period</th>
+          <th class="num">Calls</th>
+          <th class="num">Input</th>
+          <th class="num">Output</th>
+          <th class="num">Cache</th>
+          <th class="num">Cost</th>
+        </tr></thead>
+        <tbody>\${rows}</tbody>
+      </table>\`;
   };
 
   const renderModels = (data) => {
@@ -489,6 +527,7 @@ export function renderDashboard(): string {
       }
       currentData = await res.json();
       renderTopStats(currentData);
+      renderPeriods(currentData);
       renderCharts(currentData);
       renderModels(currentData);
       renderClients(currentData);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -195,10 +195,11 @@ export function renderDashboard(): string {
         How to use this dashboard
       </summary>
       <div style="margin-top:12px;font-size:13px;line-height:1.6;color:var(--fg)">
-        <p style="margin:0 0 10px"><strong>Stats row</strong> — totals across the lifetime of this gateway: total requests, active clients (with traffic), errors, and process uptime.</p>
-        <p style="margin:0 0 10px"><strong>Requests over time</strong> — per-client traffic. Toggle <em>Last 60 min</em> / <em>Last 24 h</em> in the top-right.</p>
-        <p style="margin:0 0 10px"><strong>Clients</strong> — every entry under <code>auth.tokens</code>. Click <strong>+ Add client</strong> to generate a token, append it to <code>config.yaml</code>, and download a launcher script.</p>
-        <p style="margin:0 0 10px"><strong>Recent requests</strong> — last 50 requests with status code and duration. Updates every 5 seconds.</p>
+        <p style="margin:0 0 10px"><strong>Stats row</strong> — totals across the gateway's full history (persisted in SQLite): requests, accumulated cost (USD list price), tokens, active clients, errors, uptime.</p>
+        <p style="margin:0 0 10px"><strong>Requests over time</strong> — per-client traffic. Toggle <em>Last 60 min</em> / <em>Last 24 h</em>.</p>
+        <p style="margin:0 0 10px"><strong>By model</strong> — per-model totals: calls, input/output/cache tokens, and cost. Cost uses Anthropic public list prices.</p>
+        <p style="margin:0 0 10px"><strong>Clients</strong> — every entry under <code>auth.tokens</code>, with their lifetime calls / tokens / cost. Click <strong>+ Add client</strong> to generate a token, append it to <code>config.yaml</code>, and download a launcher script.</p>
+        <p style="margin:0 0 10px"><strong>Recent requests</strong> — last 50 requests with model, tokens, cost, and duration. Updates every 5 seconds.</p>
         <p style="margin:0">After downloading <code>cc-&lt;name&gt;</code>, send it to the user. They run:</p>
 <pre style="background:var(--panel-2);border:1px solid var(--border);border-radius:6px;padding:10px 12px;font-family:var(--mono);font-size:12px;overflow-x:auto;margin:8px 0 0">chmod +x cc-&lt;name&gt;
 ./cc-&lt;name&gt; install      # install as 'ccg' system-wide (optional)
@@ -208,6 +209,10 @@ export function renderDashboard(): string {
     <div class="card">
       <h2>Requests over time (per client)</h2>
       <div id="charts" class="grid"></div>
+    </div>
+    <div class="card">
+      <h2>By model</h2>
+      <div id="modelsTable"></div>
     </div>
     <div class="card">
       <h2>
@@ -271,7 +276,24 @@ export function renderDashboard(): string {
 (() => {
   const range = () => document.getElementById('rangeSel').value;
 
-  const fmtNum = (n) => n.toLocaleString();
+  const fmtNum = (n) => (n || 0).toLocaleString();
+  const fmtTokens = (n) => {
+    n = n || 0;
+    if (n < 1000) return String(n);
+    if (n < 1_000_000) return (n / 1000).toFixed(1).replace(/\\.0$/, '') + 'k';
+    return (n / 1_000_000).toFixed(2).replace(/\\.00$/, '') + 'M';
+  };
+  const fmtCost = (n) => {
+    n = n || 0;
+    if (n === 0) return '$0';
+    if (n < 0.01) return '$' + n.toFixed(4);
+    if (n < 100) return '$' + n.toFixed(2);
+    return '$' + Math.round(n).toLocaleString();
+  };
+  const shortModel = (m) => {
+    if (!m) return '—';
+    return m.replace(/^claude-/, '').replace(/-\\d{8}$/, '');
+  };
   const fmtAgo = (ts) => {
     const d = Math.max(0, Date.now() - ts);
     if (d < 1000) return 'just now';
@@ -299,8 +321,11 @@ export function renderDashboard(): string {
   const renderTopStats = (data) => {
     const t = data.totals;
     const errRate = t.total ? ((t.errors / t.total) * 100).toFixed(1) : '0.0';
+    const totalTokens = (t.inputTokens || 0) + (t.outputTokens || 0);
     const html = [
       ['Total requests', fmtNum(t.total)],
+      ['Total cost', fmtCost(t.costUsd)],
+      ['Total tokens', fmtTokens(totalTokens)],
       ['Active clients', fmtNum(data.clients.length)],
       ['Errors', fmtNum(t.errors) + ' (' + errRate + '%)'],
       ['Uptime', fmtUptime(data.uptimeMs)],
@@ -310,6 +335,39 @@ export function renderDashboard(): string {
         <div class="label">\${label}</div>
       </div>\`).join('');
     document.getElementById('topStats').innerHTML = html;
+  };
+
+  const renderModels = (data) => {
+    const el = document.getElementById('modelsTable');
+    if (!data.models || !data.models.length) {
+      el.innerHTML = '<div class="empty">No model usage recorded yet</div>';
+      return;
+    }
+    const rows = data.models.map(m => {
+      const totalTokens = (m.inputTokens || 0) + (m.outputTokens || 0);
+      return \`<tr>
+        <td><strong>\${shortModel(m.model)}</strong></td>
+        <td class="num">\${fmtNum(m.total)}</td>
+        <td class="num">\${fmtTokens(m.inputTokens)}</td>
+        <td class="num">\${fmtTokens(m.outputTokens)}</td>
+        <td class="num">\${fmtTokens(m.cacheReadTokens)}</td>
+        <td class="num">\${fmtTokens(m.cacheCreationTokens)}</td>
+        <td class="num"><strong>\${fmtCost(m.costUsd)}</strong></td>
+      </tr>\`;
+    }).join('');
+    el.innerHTML = \`
+      <table>
+        <thead><tr>
+          <th>Model</th>
+          <th class="num">Calls</th>
+          <th class="num">Input</th>
+          <th class="num">Output</th>
+          <th class="num">Cache read</th>
+          <th class="num">Cache write</th>
+          <th class="num">Cost</th>
+        </tr></thead>
+        <tbody>\${rows}</tbody>
+      </table>\`;
   };
 
   const renderCharts = (data) => {
@@ -346,10 +404,13 @@ export function renderDashboard(): string {
     }
     const rows = data.clients.map(c => {
       const s = statusClass(c.byStatus);
+      const totalTokens = (c.inputTokens || 0) + (c.outputTokens || 0);
       return \`<tr>
         <td><strong>\${c.name}</strong></td>
         <td class="num">\${fmtNum(c.total)}</td>
-        <td><span class="pill ok">\${s.ok} 2xx</span> <span class="pill warn">\${s.warn} 4xx</span> <span class="pill err">\${s.err} 5xx</span></td>
+        <td class="num" title="input \${fmtNum(c.inputTokens)} · output \${fmtNum(c.outputTokens)} · cache_r \${fmtNum(c.cacheReadTokens)} · cache_w \${fmtNum(c.cacheCreationTokens)}">\${fmtTokens(totalTokens)}</td>
+        <td class="num"><strong>\${fmtCost(c.costUsd)}</strong></td>
+        <td><span class="pill ok">\${s.ok}</span> <span class="pill warn">\${s.warn}</span> <span class="pill err">\${s.err}</span></td>
         <td class="num">\${c.avgDurationMs}ms</td>
         <td class="ago">\${fmtAgo(c.lastSeen)}</td>
       </tr>\`;
@@ -357,7 +418,13 @@ export function renderDashboard(): string {
     document.getElementById('clientsTable').innerHTML = \`
       <table>
         <thead><tr>
-          <th>Client</th><th class="num">Total</th><th>Status</th><th class="num">Avg</th><th>Last seen</th>
+          <th>Client</th>
+          <th class="num">Calls</th>
+          <th class="num">Tokens</th>
+          <th class="num">Cost</th>
+          <th>2xx / 4xx / 5xx</th>
+          <th class="num">Avg</th>
+          <th>Last seen</th>
         </tr></thead>
         <tbody>\${rows}</tbody>
       </table>\`;
@@ -370,6 +437,10 @@ export function renderDashboard(): string {
     }
     const rows = data.recent.map(r => {
       const cls = r.status >= 500 ? 'err' : r.status >= 400 ? 'warn' : 'ok';
+      const tt = (r.inputTokens || 0) + (r.outputTokens || 0);
+      const tokenLabel = tt
+        ? fmtTokens(tt) + ' (' + fmtTokens(r.inputTokens) + '↓ ' + fmtTokens(r.outputTokens) + '↑)'
+        : '—';
       return \`<tr>
         <td class="ago">\${fmtAgo(r.ts)}</td>
         <td>\${r.client}</td>
@@ -377,12 +448,16 @@ export function renderDashboard(): string {
         <td class="path" title="\${r.path}">\${r.path}</td>
         <td><span class="pill \${cls}">\${r.status}</span></td>
         <td class="num">\${r.durationMs}ms</td>
+        <td class="num" title="model: \${r.model || '—'}">\${tokenLabel}</td>
+        <td class="num">\${r.costUsd ? fmtCost(r.costUsd) : '—'}</td>
       </tr>\`;
     }).join('');
     document.getElementById('recentTable').innerHTML = \`
       <table>
         <thead><tr>
-          <th>When</th><th>Client</th><th>Method</th><th>Path</th><th>Status</th><th class="num">Duration</th>
+          <th>When</th><th>Client</th><th>Method</th><th>Path</th>
+          <th>Status</th><th class="num">Duration</th>
+          <th class="num">Tokens</th><th class="num">Cost</th>
         </tr></thead>
         <tbody>\${rows}</tbody>
       </table>\`;
@@ -404,6 +479,7 @@ export function renderDashboard(): string {
       currentData = await res.json();
       renderTopStats(currentData);
       renderCharts(currentData);
+      renderModels(currentData);
       renderClients(currentData);
       renderRecent(currentData);
       document.getElementById('updated').textContent = 'updated ' + new Date().toLocaleTimeString();

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -156,6 +156,20 @@ export function renderDashboard(): string {
   .modal-box input:focus, .modal-box select:focus { outline: none; border-color: var(--accent); }
   .error { background: rgba(248,81,73,.1); border: 1px solid rgba(248,81,73,.3); color: var(--err); padding: 8px 10px; border-radius: 6px; font-size: 13px; }
   .config-info { background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; font-size: 12px; color: var(--muted); font-family: var(--mono); }
+  .snippet-block { position: relative; }
+  .snippet-block pre {
+    background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+    padding: 10px 12px; font-family: var(--mono); font-size: 12px;
+    color: var(--fg); margin: 0; overflow-x: auto; white-space: pre;
+  }
+  .copy-btn {
+    position: absolute; top: 6px; right: 6px;
+    padding: 4px 10px; font-size: 11px;
+    background: var(--panel-2); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
+  }
+  .copy-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .copy-btn.copied { color: var(--ok); border-color: var(--ok); }
 </style>
 </head>
 <body>
@@ -176,6 +190,21 @@ export function renderDashboard(): string {
 <main>
   <div class="grid">
     <div class="row" id="topStats"></div>
+    <details class="card" id="aboutCard">
+      <summary style="cursor:pointer;font-weight:600;font-size:13px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em">
+        How to use this dashboard
+      </summary>
+      <div style="margin-top:12px;font-size:13px;line-height:1.6;color:var(--fg)">
+        <p style="margin:0 0 10px"><strong>Stats row</strong> — totals across the lifetime of this gateway: total requests, active clients (with traffic), errors, and process uptime.</p>
+        <p style="margin:0 0 10px"><strong>Requests over time</strong> — per-client traffic. Toggle <em>Last 60 min</em> / <em>Last 24 h</em> in the top-right.</p>
+        <p style="margin:0 0 10px"><strong>Clients</strong> — every entry under <code>auth.tokens</code>. Click <strong>+ Add client</strong> to generate a token, append it to <code>config.yaml</code>, and download a launcher script.</p>
+        <p style="margin:0 0 10px"><strong>Recent requests</strong> — last 50 requests with status code and duration. Updates every 5 seconds.</p>
+        <p style="margin:0">After downloading <code>cc-&lt;name&gt;</code>, send it to the user. They run:</p>
+<pre style="background:var(--panel-2);border:1px solid var(--border);border-radius:6px;padding:10px 12px;font-family:var(--mono);font-size:12px;overflow-x:auto;margin:8px 0 0">chmod +x cc-&lt;name&gt;
+./cc-&lt;name&gt; install      # install as 'ccg' system-wide (optional)
+./cc-&lt;name&gt;              # or run directly without installing</pre>
+      </div>
+    </details>
     <div class="card">
       <h2>Requests over time (per client)</h2>
       <div id="charts" class="grid"></div>
@@ -197,21 +226,44 @@ export function renderDashboard(): string {
 
 <div id="addClientModal" class="modal" style="display:none">
   <div class="modal-box">
-    <h3>Add client</h3>
-    <p class="meta" style="margin:0 0 16px">Generates a token, appends it to <code>config.yaml</code>, and downloads a launcher script.</p>
-    <label>Client name</label>
-    <input id="cName" placeholder="e.g. vuluu2k" autocomplete="off" />
-    <label>Gateway address</label>
-    <input id="cAddr" placeholder="ccg.example.com" autocomplete="off" />
-    <label>Scheme</label>
-    <select id="cScheme">
-      <option value="https">https</option>
-      <option value="http">http</option>
-    </select>
-    <div id="cError" class="error" style="display:none;margin-top:12px"></div>
-    <div style="display:flex;gap:8px;margin-top:18px;justify-content:flex-end">
-      <button id="cCancel" type="button">Cancel</button>
-      <button id="cSubmit" type="button" class="primary">Create &amp; download</button>
+    <div id="modalForm">
+      <h3>Add client</h3>
+      <p class="meta" style="margin:0 0 16px">Generates a token, appends it to <code>config.yaml</code>, and downloads a launcher script.</p>
+      <label>Client name</label>
+      <input id="cName" placeholder="e.g. vuluu2k" autocomplete="off" />
+      <label>Gateway address</label>
+      <input id="cAddr" placeholder="ccg.example.com" autocomplete="off" />
+      <label>Scheme</label>
+      <select id="cScheme">
+        <option value="https">https</option>
+        <option value="http">http</option>
+      </select>
+      <div id="cError" class="error" style="display:none;margin-top:12px"></div>
+      <div style="display:flex;gap:8px;margin-top:18px;justify-content:flex-end">
+        <button id="cCancel" type="button">Cancel</button>
+        <button id="cSubmit" type="button" class="primary">Create &amp; download</button>
+      </div>
+    </div>
+
+    <div id="modalSuccess" style="display:none">
+      <h3>Client created · <span id="successName"></span></h3>
+      <p class="meta" style="margin:0 0 16px">File <code id="successFile"></code> has been downloaded. Send it to the user and ask them to run:</p>
+      <div class="snippet-block">
+        <pre id="successCmd"></pre>
+        <button id="copyCmdBtn" type="button" class="copy-btn">Copy</button>
+      </div>
+      <p class="meta" style="margin:14px 0 8px">Or to install system-wide as <code>ccg</code>:</p>
+      <div class="snippet-block">
+        <pre id="installCmd"></pre>
+        <button id="copyInstallBtn" type="button" class="copy-btn">Copy</button>
+      </div>
+      <p class="meta" style="margin:14px 0 0;font-size:12px">
+        Prerequisites: claude code installed (<code>npm install -g @anthropic-ai/claude-code</code>).
+        On macOS, if Gatekeeper blocks the file: <code>xattr -d com.apple.quarantine cc-&lt;name&gt;</code>.
+      </p>
+      <div style="display:flex;gap:8px;margin-top:18px;justify-content:flex-end">
+        <button id="successDone" type="button" class="primary">Done</button>
+      </div>
     </div>
   </div>
 </div>
@@ -420,10 +472,47 @@ export function renderDashboard(): string {
     document.getElementById('cAddr').value = location.host;
     document.getElementById('cScheme').value = location.protocol === 'http:' ? 'http' : 'https';
     showError(null);
+    document.getElementById('modalForm').style.display = 'block';
+    document.getElementById('modalSuccess').style.display = 'none';
     document.getElementById('addClientModal').style.display = 'flex';
     setTimeout(() => document.getElementById('cName').focus(), 0);
   };
   const closeModal = () => { document.getElementById('addClientModal').style.display = 'none'; };
+
+  const showSuccess = (name) => {
+    document.getElementById('modalForm').style.display = 'none';
+    const sucEl = document.getElementById('modalSuccess');
+    sucEl.style.display = 'block';
+    document.getElementById('successName').textContent = name;
+    document.getElementById('successFile').textContent = 'cc-' + name;
+    document.getElementById('successCmd').textContent =
+      'chmod +x cc-' + name + ' && ./cc-' + name;
+    document.getElementById('installCmd').textContent =
+      'chmod +x cc-' + name + ' && ./cc-' + name + ' install';
+  };
+
+  const wireCopyButton = (btnId, sourceId) => {
+    document.getElementById(btnId).addEventListener('click', async (e) => {
+      const btn = e.currentTarget;
+      const text = document.getElementById(sourceId).textContent;
+      try {
+        await navigator.clipboard.writeText(text);
+        btn.textContent = 'Copied';
+        btn.classList.add('copied');
+        setTimeout(() => {
+          btn.textContent = 'Copy';
+          btn.classList.remove('copied');
+        }, 1500);
+      } catch {
+        // fallback: select text
+        const range = document.createRange();
+        range.selectNodeContents(document.getElementById(sourceId));
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    });
+  };
 
   const submitClient = async () => {
     const name = document.getElementById('cName').value.trim();
@@ -453,7 +542,7 @@ export function renderDashboard(): string {
       a.click();
       a.remove();
       URL.revokeObjectURL(url);
-      closeModal();
+      showSuccess(name);
       loadClients();
     } finally {
       submitBtn.disabled = false;
@@ -463,6 +552,9 @@ export function renderDashboard(): string {
   document.getElementById('addClientBtn').addEventListener('click', openModal);
   document.getElementById('cCancel').addEventListener('click', closeModal);
   document.getElementById('cSubmit').addEventListener('click', submitClient);
+  document.getElementById('successDone').addEventListener('click', closeModal);
+  wireCopyButton('copyCmdBtn', 'successCmd');
+  wireCopyButton('copyInstallBtn', 'installCmd');
   document.getElementById('addClientModal').addEventListener('click', (e) => {
     if (e.target.id === 'addClientModal') closeModal();
   });

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,66 @@
+import Database from 'better-sqlite3'
+import { mkdirSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { randomBytes } from 'crypto'
+
+let db: Database.Database | null = null
+
+export function initDb(path: string): Database.Database {
+  const absPath = resolve(path)
+  mkdirSync(dirname(absPath), { recursive: true })
+
+  db = new Database(absPath)
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+  db.pragma('synchronous = NORMAL')
+
+  migrate(db)
+  return db
+}
+
+export function getDb(): Database.Database {
+  if (!db) throw new Error('DB not initialized — call initDb() first')
+  return db
+}
+
+function migrate(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS request_metrics (
+      ts INTEGER NOT NULL,
+      client TEXT NOT NULL,
+      method TEXT NOT NULL,
+      path TEXT NOT NULL,
+      status INTEGER NOT NULL,
+      duration_ms INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_rm_ts ON request_metrics(ts);
+    CREATE INDEX IF NOT EXISTS idx_rm_client_ts ON request_metrics(client, ts);
+  `)
+}
+
+export function getOrCreateMeta(key: string, factory: () => string): string {
+  const db = getDb()
+  const row = db.prepare('SELECT value FROM meta WHERE key = ?').get(key) as { value: string } | undefined
+  if (row) return row.value
+  const value = factory()
+  db.prepare('INSERT INTO meta (key, value) VALUES (?, ?)').run(key, value)
+  return value
+}
+
+export function getSessionSecret(): Buffer {
+  const hex = getOrCreateMeta('session_secret', () => randomBytes(32).toString('hex'))
+  return Buffer.from(hex, 'hex')
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -49,6 +49,19 @@ function migrate(db: Database.Database) {
     CREATE INDEX IF NOT EXISTS idx_rm_ts ON request_metrics(ts);
     CREATE INDEX IF NOT EXISTS idx_rm_client_ts ON request_metrics(client, ts);
   `)
+
+  // ── 2026-05 schema bump: per-request token usage + cost ──
+  const cols = db.prepare('PRAGMA table_info(request_metrics)').all() as Array<{ name: string }>
+  const has = (n: string) => cols.some((c) => c.name === n)
+  const addCol = (sql: string) => db.exec(`ALTER TABLE request_metrics ADD COLUMN ${sql}`)
+  if (!has('model')) addCol("model TEXT NOT NULL DEFAULT ''")
+  if (!has('input_tokens')) addCol('input_tokens INTEGER NOT NULL DEFAULT 0')
+  if (!has('output_tokens')) addCol('output_tokens INTEGER NOT NULL DEFAULT 0')
+  if (!has('cache_read_tokens')) addCol('cache_read_tokens INTEGER NOT NULL DEFAULT 0')
+  if (!has('cache_creation_tokens')) addCol('cache_creation_tokens INTEGER NOT NULL DEFAULT 0')
+  if (!has('cost_usd')) addCol('cost_usd REAL NOT NULL DEFAULT 0')
+
+  db.exec('CREATE INDEX IF NOT EXISTS idx_rm_model_ts ON request_metrics(model, ts)')
 }
 
 export function getOrCreateMeta(key: string, factory: () => string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
+import { watchFile } from 'fs'
+import { resolve } from 'path'
 import { loadConfig } from './config.js'
 import { setLogLevel, log } from './logger.js'
 import { initOAuth } from './oauth.js'
 import { startProxy } from './proxy.js'
+import { initAuth } from './auth.js'
 
 const configPath = process.argv[2]
 
@@ -15,6 +18,22 @@ try {
   await initOAuth(config.oauth)
 
   startProxy(config)
+
+  // Hot-reload auth.tokens on config changes (poll-based — works with bind mounts)
+  const watchPath = resolve(configPath || 'config.yaml')
+  let lastTokenSig = JSON.stringify(config.auth.tokens)
+  watchFile(watchPath, { interval: 2000 }, () => {
+    try {
+      const next = loadConfig(configPath)
+      const sig = JSON.stringify(next.auth.tokens)
+      if (sig === lastTokenSig) return
+      initAuth(next)
+      lastTokenSig = sig
+      log('info', `Reloaded auth.tokens (${next.auth.tokens.length} entries: ${next.auth.tokens.map(t => t.name).join(', ')})`)
+    } catch (err) {
+      log('error', `Config reload failed, keeping existing tokens: ${err instanceof Error ? err.message : err}`)
+    }
+  })
 } catch (err) {
   console.error(`Fatal: ${err instanceof Error ? err.message : err}`)
   process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,25 @@ import { initAuth } from './auth.js'
 import { initDb } from './db.js'
 import { initMetrics } from './metrics.js'
 import { countUsers } from './users.js'
+import { bootstrapConfigIfMissing } from './bootstrap-config.js'
 
-const configPath = process.argv[2]
+// Resolve the config path: explicit arg > CCG_CONFIG_PATH env > /app/data/config.yaml.
+// /app/data is the persistent volume so the auto-generated config survives restarts.
+const configPath =
+  process.argv[2] ||
+  process.env.CCG_CONFIG_PATH ||
+  '/app/data/config.yaml'
 
 try {
+  if (!bootstrapConfigIfMissing(configPath)) {
+    process.exit(1)
+  }
+
   const config = loadConfig(configPath)
   setLogLevel(config.logging.level)
 
   log('info', 'CC Gateway starting...')
+  log('info', `Config: ${resolve(configPath)}`)
 
   const dbPath = config.db?.path || './data/ccg.db'
   initDb(dbPath)
@@ -31,7 +42,7 @@ try {
   startProxy(config)
 
   // Hot-reload auth.tokens on config changes (poll-based — works with bind mounts)
-  const watchPath = resolve(configPath || 'config.yaml')
+  const watchPath = resolve(configPath)
   let lastTokenSig = JSON.stringify(config.auth.tokens)
   watchFile(watchPath, { interval: 2000 }, () => {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,17 @@ import { watchFile } from 'fs'
 import { resolve } from 'path'
 import { loadConfig } from './config.js'
 import { setLogLevel, log } from './logger.js'
-import { initOAuth } from './oauth.js'
+import { initOAuth, setOnTokensUpdated } from './oauth.js'
 import { startProxy } from './proxy.js'
 import { initAuth } from './auth.js'
 import { initDb } from './db.js'
 import { initMetrics } from './metrics.js'
 import { countUsers } from './users.js'
-import { bootstrapConfigIfMissing } from './bootstrap-config.js'
+import {
+  bootstrapConfigIfMissing,
+  syncOAuthFromCredentialsIfChanged,
+  updateConfigOAuth,
+} from './bootstrap-config.js'
 
 // Resolve the config path: explicit arg > CCG_CONFIG_PATH env > /app/data/config.yaml.
 // /app/data is the persistent volume so the auto-generated config survives restarts.
@@ -22,11 +26,23 @@ try {
     process.exit(1)
   }
 
+  // If a credentials.json is mounted and its refresh_token differs from the
+  // one persisted in config.yaml (e.g. host did `claude` and rotated the
+  // token), refresh the config before we load it.
+  syncOAuthFromCredentialsIfChanged(configPath)
+
   const config = loadConfig(configPath)
   setLogLevel(config.logging.level)
 
   log('info', 'CC Gateway starting...')
   log('info', `Config: ${resolve(configPath)}`)
+
+  // Whenever OAuth refreshes (immediately or on the schedule), persist the
+  // rotated refresh_token back to config.yaml so container restarts pick up
+  // the latest valid token instead of replaying a consumed one.
+  setOnTokensUpdated((tokens) => {
+    updateConfigOAuth(configPath, tokens)
+  })
 
   const dbPath = config.db?.path || './data/ccg.db'
   initDb(dbPath)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import { setLogLevel, log } from './logger.js'
 import { initOAuth } from './oauth.js'
 import { startProxy } from './proxy.js'
 import { initAuth } from './auth.js'
+import { initDb } from './db.js'
+import { initMetrics } from './metrics.js'
+import { countUsers } from './users.js'
 
 const configPath = process.argv[2]
 
@@ -13,6 +16,14 @@ try {
   setLogLevel(config.logging.level)
 
   log('info', 'CC Gateway starting...')
+
+  const dbPath = config.db?.path || './data/ccg.db'
+  initDb(dbPath)
+  initMetrics()
+  log('info', `SQLite database: ${resolve(dbPath)}`)
+  if (countUsers() === 0) {
+    log('warn', 'No dashboard users yet. Create one with: npm run add-user <username>')
+  }
 
   // Initialize OAuth — uses existing access token if valid, only refreshes when expired
   await initOAuth(config.oauth)

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -285,10 +285,42 @@ export function getMetricsSnapshot() {
     )
     .all(RECENT_LIMIT) as RequestRecord[]
 
+  // Period summaries — easy to read "today / 7d / 30d" cost & usage
+  const day = 24 * HOUR_MS
+  const periods = [
+    { key: 'today', label: 'Today',     since: now - day },
+    { key: '7d',    label: 'Last 7d',   since: now - 7 * day },
+    { key: '30d',   label: 'Last 30d',  since: now - 30 * day },
+  ]
+  const periodStmt = db.prepare(
+    `SELECT
+      COUNT(*) as total,
+      SUM(input_tokens) as input_tokens,
+      SUM(output_tokens) as output_tokens,
+      SUM(cache_read_tokens) as cache_read_tokens,
+      SUM(cache_creation_tokens) as cache_creation_tokens,
+      SUM(cost_usd) as cost_usd
+    FROM request_metrics WHERE ts >= ?`,
+  )
+  const periodSummary = periods.map((p) => {
+    const r = periodStmt.get(p.since) as any
+    return {
+      key: p.key,
+      label: p.label,
+      total: r.total || 0,
+      inputTokens: r.input_tokens || 0,
+      outputTokens: r.output_tokens || 0,
+      cacheReadTokens: r.cache_read_tokens || 0,
+      cacheCreationTokens: r.cache_creation_tokens || 0,
+      costUsd: r.cost_usd || 0,
+    }
+  })
+
   return {
     now,
     uptimeMs: now - startedAt,
     totals,
+    periods: periodSummary,
     clients,
     models,
     minuteSeries,

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,203 @@
+import { getDb } from './db.js'
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 3_600_000
+const MINUTES_KEPT = 60
+const HOURS_KEPT = 24
+const RETENTION_DAYS = 30
+const RECENT_LIMIT = 50
+
+export interface RequestRecord {
+  ts: number
+  client: string
+  method: string
+  path: string
+  status: number
+  durationMs: number
+}
+
+let startedAt = Date.now()
+let cleanupTimer: NodeJS.Timeout | null = null
+
+export function initMetrics() {
+  startedAt = Date.now()
+  pruneOldRows()
+  if (cleanupTimer) clearInterval(cleanupTimer)
+  cleanupTimer = setInterval(pruneOldRows, HOUR_MS).unref()
+}
+
+function pruneOldRows() {
+  const cutoff = Date.now() - RETENTION_DAYS * 24 * HOUR_MS
+  try {
+    getDb().prepare('DELETE FROM request_metrics WHERE ts < ?').run(cutoff)
+  } catch {
+    // DB may not be initialized yet during early startup
+  }
+}
+
+export function recordRequest(rec: RequestRecord) {
+  try {
+    getDb()
+      .prepare(
+        'INSERT INTO request_metrics (ts, client, method, path, status, duration_ms) VALUES (?, ?, ?, ?, ?, ?)',
+      )
+      .run(rec.ts, rec.client, rec.method, rec.path, rec.status, rec.durationMs)
+  } catch (err) {
+    // Don't break proxying on metrics failures
+  }
+}
+
+interface ClientRow {
+  client: string
+  total: number
+  errors: number
+  total_duration: number
+  first_seen: number
+  last_seen: number
+  s2xx: number
+  s3xx: number
+  s4xx: number
+  s5xx: number
+  m_get: number
+  m_post: number
+  m_put: number
+  m_delete: number
+  m_other: number
+}
+
+export function getMetricsSnapshot() {
+  const db = getDb()
+  const now = Date.now()
+  const currentMinute = Math.floor(now / MINUTE_MS) * MINUTE_MS
+  const currentHour = Math.floor(now / HOUR_MS) * HOUR_MS
+
+  const totalsRow = db
+    .prepare(
+      `SELECT
+        COUNT(*) as total,
+        SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) as errors
+      FROM request_metrics`,
+    )
+    .get() as { total: number; errors: number | null }
+
+  const totals = {
+    total: totalsRow.total || 0,
+    errors: totalsRow.errors || 0,
+    startedAt,
+  }
+
+  const clientRows = db
+    .prepare(
+      `SELECT
+        client,
+        COUNT(*) as total,
+        SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) as errors,
+        SUM(duration_ms) as total_duration,
+        MIN(ts) as first_seen,
+        MAX(ts) as last_seen,
+        SUM(CASE WHEN status >= 200 AND status < 300 THEN 1 ELSE 0 END) as s2xx,
+        SUM(CASE WHEN status >= 300 AND status < 400 THEN 1 ELSE 0 END) as s3xx,
+        SUM(CASE WHEN status >= 400 AND status < 500 THEN 1 ELSE 0 END) as s4xx,
+        SUM(CASE WHEN status >= 500 THEN 1 ELSE 0 END) as s5xx,
+        SUM(CASE WHEN method = 'GET' THEN 1 ELSE 0 END) as m_get,
+        SUM(CASE WHEN method = 'POST' THEN 1 ELSE 0 END) as m_post,
+        SUM(CASE WHEN method = 'PUT' THEN 1 ELSE 0 END) as m_put,
+        SUM(CASE WHEN method = 'DELETE' THEN 1 ELSE 0 END) as m_delete,
+        SUM(CASE WHEN method NOT IN ('GET','POST','PUT','DELETE') THEN 1 ELSE 0 END) as m_other
+      FROM request_metrics
+      GROUP BY client
+      ORDER BY total DESC`,
+    )
+    .all() as ClientRow[]
+
+  const clients = clientRows.map((r) => {
+    const byStatus: Record<string, number> = {}
+    if (r.s2xx) byStatus['2xx'] = r.s2xx
+    if (r.s3xx) byStatus['3xx'] = r.s3xx
+    if (r.s4xx) byStatus['4xx'] = r.s4xx
+    if (r.s5xx) byStatus['5xx'] = r.s5xx
+    const byMethod: Record<string, number> = {}
+    if (r.m_get) byMethod['GET'] = r.m_get
+    if (r.m_post) byMethod['POST'] = r.m_post
+    if (r.m_put) byMethod['PUT'] = r.m_put
+    if (r.m_delete) byMethod['DELETE'] = r.m_delete
+    if (r.m_other) byMethod['OTHER'] = r.m_other
+    return {
+      name: r.client,
+      total: r.total,
+      errors: r.errors,
+      totalDurationMs: r.total_duration,
+      avgDurationMs: r.total > 0 ? Math.round(r.total_duration / r.total) : 0,
+      firstSeen: r.first_seen,
+      lastSeen: r.last_seen,
+      byStatus,
+      byMethod,
+    }
+  })
+
+  const minuteStart = currentMinute - (MINUTES_KEPT - 1) * MINUTE_MS
+  const hourStart = currentHour - (HOURS_KEPT - 1) * HOUR_MS
+
+  const minuteRows = db
+    .prepare(
+      `SELECT client, (ts / ${MINUTE_MS}) * ${MINUTE_MS} as bucket, COUNT(*) as count
+       FROM request_metrics
+       WHERE ts >= ?
+       GROUP BY client, bucket`,
+    )
+    .all(minuteStart) as Array<{ client: string; bucket: number; count: number }>
+
+  const hourRows = db
+    .prepare(
+      `SELECT client, (ts / ${HOUR_MS}) * ${HOUR_MS} as bucket, COUNT(*) as count
+       FROM request_metrics
+       WHERE ts >= ?
+       GROUP BY client, bucket`,
+    )
+    .all(hourStart) as Array<{ client: string; bucket: number; count: number }>
+
+  const minuteSeries: Record<string, Array<{ ts: number; count: number }>> = {}
+  const hourSeries: Record<string, Array<{ ts: number; count: number }>> = {}
+
+  for (const c of clients) {
+    minuteSeries[c.name] = []
+    for (let i = MINUTES_KEPT - 1; i >= 0; i--) {
+      minuteSeries[c.name].push({ ts: currentMinute - i * MINUTE_MS, count: 0 })
+    }
+    hourSeries[c.name] = []
+    for (let i = HOURS_KEPT - 1; i >= 0; i--) {
+      hourSeries[c.name].push({ ts: currentHour - i * HOUR_MS, count: 0 })
+    }
+  }
+  for (const r of minuteRows) {
+    const series = minuteSeries[r.client]
+    if (!series) continue
+    const point = series.find((p) => p.ts === r.bucket)
+    if (point) point.count = r.count
+  }
+  for (const r of hourRows) {
+    const series = hourSeries[r.client]
+    if (!series) continue
+    const point = series.find((p) => p.ts === r.bucket)
+    if (point) point.count = r.count
+  }
+
+  const recent = db
+    .prepare(
+      `SELECT ts, client, method, path, status, duration_ms as durationMs
+       FROM request_metrics
+       ORDER BY ts DESC
+       LIMIT ?`,
+    )
+    .all(RECENT_LIMIT) as RequestRecord[]
+
+  return {
+    now,
+    uptimeMs: now - startedAt,
+    totals,
+    clients,
+    minuteSeries,
+    hourSeries,
+    recent,
+  }
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -14,6 +14,12 @@ export interface RequestRecord {
   path: string
   status: number
   durationMs: number
+  model?: string
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
+  costUsd?: number
 }
 
 let startedAt = Date.now()
@@ -39,9 +45,21 @@ export function recordRequest(rec: RequestRecord) {
   try {
     getDb()
       .prepare(
-        'INSERT INTO request_metrics (ts, client, method, path, status, duration_ms) VALUES (?, ?, ?, ?, ?, ?)',
+        `INSERT INTO request_metrics (
+          ts, client, method, path, status, duration_ms,
+          model, input_tokens, output_tokens,
+          cache_read_tokens, cache_creation_tokens, cost_usd
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(rec.ts, rec.client, rec.method, rec.path, rec.status, rec.durationMs)
+      .run(
+        rec.ts, rec.client, rec.method, rec.path, rec.status, rec.durationMs,
+        rec.model || '',
+        rec.inputTokens || 0,
+        rec.outputTokens || 0,
+        rec.cacheReadTokens || 0,
+        rec.cacheCreationTokens || 0,
+        rec.costUsd || 0,
+      )
   } catch (err) {
     // Don't break proxying on metrics failures
   }
@@ -63,6 +81,11 @@ interface ClientRow {
   m_put: number
   m_delete: number
   m_other: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_creation_tokens: number
+  cost_usd: number
 }
 
 export function getMetricsSnapshot() {
@@ -75,14 +98,32 @@ export function getMetricsSnapshot() {
     .prepare(
       `SELECT
         COUNT(*) as total,
-        SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) as errors
+        SUM(CASE WHEN status >= 400 THEN 1 ELSE 0 END) as errors,
+        SUM(input_tokens) as input_tokens,
+        SUM(output_tokens) as output_tokens,
+        SUM(cache_read_tokens) as cache_read_tokens,
+        SUM(cache_creation_tokens) as cache_creation_tokens,
+        SUM(cost_usd) as cost_usd
       FROM request_metrics`,
     )
-    .get() as { total: number; errors: number | null }
+    .get() as {
+      total: number
+      errors: number | null
+      input_tokens: number | null
+      output_tokens: number | null
+      cache_read_tokens: number | null
+      cache_creation_tokens: number | null
+      cost_usd: number | null
+    }
 
   const totals = {
     total: totalsRow.total || 0,
     errors: totalsRow.errors || 0,
+    inputTokens: totalsRow.input_tokens || 0,
+    outputTokens: totalsRow.output_tokens || 0,
+    cacheReadTokens: totalsRow.cache_read_tokens || 0,
+    cacheCreationTokens: totalsRow.cache_creation_tokens || 0,
+    costUsd: totalsRow.cost_usd || 0,
     startedAt,
   }
 
@@ -103,12 +144,42 @@ export function getMetricsSnapshot() {
         SUM(CASE WHEN method = 'POST' THEN 1 ELSE 0 END) as m_post,
         SUM(CASE WHEN method = 'PUT' THEN 1 ELSE 0 END) as m_put,
         SUM(CASE WHEN method = 'DELETE' THEN 1 ELSE 0 END) as m_delete,
-        SUM(CASE WHEN method NOT IN ('GET','POST','PUT','DELETE') THEN 1 ELSE 0 END) as m_other
+        SUM(CASE WHEN method NOT IN ('GET','POST','PUT','DELETE') THEN 1 ELSE 0 END) as m_other,
+        SUM(input_tokens) as input_tokens,
+        SUM(output_tokens) as output_tokens,
+        SUM(cache_read_tokens) as cache_read_tokens,
+        SUM(cache_creation_tokens) as cache_creation_tokens,
+        SUM(cost_usd) as cost_usd
       FROM request_metrics
       GROUP BY client
       ORDER BY total DESC`,
     )
     .all() as ClientRow[]
+
+  const modelRows = db
+    .prepare(
+      `SELECT
+        model,
+        COUNT(*) as total,
+        SUM(input_tokens) as input_tokens,
+        SUM(output_tokens) as output_tokens,
+        SUM(cache_read_tokens) as cache_read_tokens,
+        SUM(cache_creation_tokens) as cache_creation_tokens,
+        SUM(cost_usd) as cost_usd
+      FROM request_metrics
+      WHERE model != ''
+      GROUP BY model
+      ORDER BY cost_usd DESC`,
+    )
+    .all() as Array<{
+      model: string
+      total: number
+      input_tokens: number
+      output_tokens: number
+      cache_read_tokens: number
+      cache_creation_tokens: number
+      cost_usd: number
+    }>
 
   const clients = clientRows.map((r) => {
     const byStatus: Record<string, number> = {}
@@ -132,8 +203,23 @@ export function getMetricsSnapshot() {
       lastSeen: r.last_seen,
       byStatus,
       byMethod,
+      inputTokens: r.input_tokens || 0,
+      outputTokens: r.output_tokens || 0,
+      cacheReadTokens: r.cache_read_tokens || 0,
+      cacheCreationTokens: r.cache_creation_tokens || 0,
+      costUsd: r.cost_usd || 0,
     }
   })
+
+  const models = modelRows.map((r) => ({
+    model: r.model,
+    total: r.total,
+    inputTokens: r.input_tokens || 0,
+    outputTokens: r.output_tokens || 0,
+    cacheReadTokens: r.cache_read_tokens || 0,
+    cacheCreationTokens: r.cache_creation_tokens || 0,
+    costUsd: r.cost_usd || 0,
+  }))
 
   const minuteStart = currentMinute - (MINUTES_KEPT - 1) * MINUTE_MS
   const hourStart = currentHour - (HOURS_KEPT - 1) * HOUR_MS
@@ -184,7 +270,15 @@ export function getMetricsSnapshot() {
 
   const recent = db
     .prepare(
-      `SELECT ts, client, method, path, status, duration_ms as durationMs
+      `SELECT
+        ts, client, method, path, status,
+        duration_ms as durationMs,
+        model,
+        input_tokens as inputTokens,
+        output_tokens as outputTokens,
+        cache_read_tokens as cacheReadTokens,
+        cache_creation_tokens as cacheCreationTokens,
+        cost_usd as costUsd
        FROM request_metrics
        ORDER BY ts DESC
        LIMIT ?`,
@@ -196,6 +290,7 @@ export function getMetricsSnapshot() {
     uptimeMs: now - startedAt,
     totals,
     clients,
+    models,
     minuteSeries,
     hourSeries,
     recent,

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -19,6 +19,20 @@ type OAuthTokens = {
 }
 
 let cachedTokens: OAuthTokens | null = null
+let onTokensUpdated: ((tokens: OAuthTokens) => void) | null = null
+
+export function setOnTokensUpdated(cb: (tokens: OAuthTokens) => void) {
+  onTokensUpdated = cb
+}
+
+function persistTokens(tokens: OAuthTokens) {
+  if (!onTokensUpdated) return
+  try {
+    onTokensUpdated(tokens)
+  } catch (err) {
+    log('warn', `Token persist callback threw: ${err instanceof Error ? err.message : err}`)
+  }
+}
 
 /**
  * Initialize OAuth.
@@ -55,6 +69,7 @@ export async function initOAuth(oauth: {
   }
 
   cachedTokens = await refreshOAuthToken(oauth.refresh_token)
+  persistTokens(cachedTokens)
   log('info', `OAuth token acquired, expires at ${new Date(cachedTokens.expiresAt).toISOString()}`)
   scheduleRefresh(oauth.refresh_token)
 }
@@ -71,6 +86,7 @@ function scheduleRefresh(refreshToken: string) {
       cachedTokens = await refreshOAuthToken(
         cachedTokens?.refreshToken || refreshToken,
       )
+      persistTokens(cachedTokens)
       log('info', `OAuth token refreshed, expires at ${new Date(cachedTokens.expiresAt).toISOString()}`)
       scheduleRefresh(cachedTokens.refreshToken || refreshToken)
     } catch (err) {

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -1,0 +1,68 @@
+// Anthropic public list prices in USD per 1M tokens, as of 2026-05.
+// When a request reports a model id we don't recognise, we fall back to the
+// most specific family match (sonnet/opus/haiku) and finally to sonnet rates.
+
+export interface Pricing {
+  input: number          // per 1M input tokens
+  output: number         // per 1M output tokens
+  cacheRead: number      // per 1M cache-read input tokens
+  cacheWrite: number     // per 1M cache-creation input tokens
+}
+
+const RATES: Record<string, Pricing> = {
+  // Claude 4.x family (current)
+  'claude-opus-4-7':       { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+  'claude-opus-4-6':       { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+  'claude-opus-4-5':       { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+  'claude-sonnet-4-7':     { input:  3.00, output: 15.00, cacheRead: 0.30, cacheWrite:  3.75 },
+  'claude-sonnet-4-6':     { input:  3.00, output: 15.00, cacheRead: 0.30, cacheWrite:  3.75 },
+  'claude-sonnet-4-5':     { input:  3.00, output: 15.00, cacheRead: 0.30, cacheWrite:  3.75 },
+  'claude-haiku-4-5':      { input:  0.80, output:  4.00, cacheRead: 0.08, cacheWrite:  1.00 },
+  // 3.x family (older but may still appear)
+  'claude-3-7-sonnet':     { input:  3.00, output: 15.00, cacheRead: 0.30, cacheWrite:  3.75 },
+  'claude-3-5-sonnet':     { input:  3.00, output: 15.00, cacheRead: 0.30, cacheWrite:  3.75 },
+  'claude-3-5-haiku':      { input:  0.80, output:  4.00, cacheRead: 0.08, cacheWrite:  1.00 },
+  'claude-3-opus':         { input: 15.00, output: 75.00, cacheRead: 1.50, cacheWrite: 18.75 },
+}
+
+function lookupRate(model: string): Pricing {
+  const key = model.toLowerCase()
+  // Exact match by stripping date suffix: "claude-sonnet-4-5-20250929" → "claude-sonnet-4-5"
+  for (const id of Object.keys(RATES)) {
+    if (key === id || key.startsWith(id + '-')) return RATES[id]
+  }
+  // Family fallback
+  if (key.includes('opus'))   return RATES['claude-opus-4-7']
+  if (key.includes('haiku'))  return RATES['claude-haiku-4-5']
+  return RATES['claude-sonnet-4-7']
+}
+
+export interface UsageBreakdown {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+}
+
+export function computeCost(model: string, u: UsageBreakdown): number {
+  const r = lookupRate(model || '')
+  return (
+    (u.inputTokens          / 1_000_000) * r.input +
+    (u.outputTokens         / 1_000_000) * r.output +
+    (u.cacheReadTokens      / 1_000_000) * r.cacheRead +
+    (u.cacheCreationTokens  / 1_000_000) * r.cacheWrite
+  )
+}
+
+export function formatCost(usd: number): string {
+  if (usd < 0.0001) return '$0.0000'
+  if (usd < 1) return '$' + usd.toFixed(4)
+  if (usd < 100) return '$' + usd.toFixed(2)
+  return '$' + Math.round(usd).toLocaleString()
+}
+
+export function formatTokens(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k'
+  return (n / 1_000_000).toFixed(2).replace(/\.00$/, '') + 'M'
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,8 @@ import { rewriteBody, rewriteHeaders } from './rewriter.js'
 import { audit, log } from './logger.js'
 import { getProxyAgent } from './proxy-agent.js'
 import { recordRequest, getMetricsSnapshot } from './metrics.js'
+import { SSEUsageParser } from './usage-parser.js'
+import { computeCost } from './pricing.js'
 import { renderDashboard, renderLogin } from './dashboard.js'
 import { authenticateUser } from './users.js'
 import {
@@ -152,22 +154,9 @@ async function handleRequest(
     config,
   )
 
-  // Inject the OAuth access_token. Anthropic OAuth tokens (sk-ant-oat01-) must
-  // be sent via Authorization: Bearer with the anthropic-beta: oauth-2025-04-20
-  // flag — sending them via x-api-key returns 401 "Invalid authentication
-  // credentials". rewriteHeaders() already stripped any inbound auth headers.
-  delete rewrittenHeaders['x-api-key']
-  rewrittenHeaders['authorization'] = `Bearer ${oauthToken}`
-
-  const oauthBetaFlag = 'oauth-2025-04-20'
-  const existingBeta = rewrittenHeaders['anthropic-beta']
-  if (existingBeta) {
-    if (!existingBeta.split(',').map((s) => s.trim()).includes(oauthBetaFlag)) {
-      rewrittenHeaders['anthropic-beta'] = `${existingBeta},${oauthBetaFlag}`
-    }
-  } else {
-    rewrittenHeaders['anthropic-beta'] = oauthBetaFlag
-  }
+  // Inject the real OAuth token via x-api-key (Anthropic uses this header for both
+  // API keys and OAuth tokens, distinguished by prefix: sk-ant-api03- vs sk-ant-oat01-)
+  rewrittenHeaders['x-api-key'] = oauthToken
 
   // Forward to upstream
   const upstreamUrl = new URL(path, upstream)
@@ -192,13 +181,21 @@ async function handleRequest(
 
       res.writeHead(status, responseHeaders)
 
-      // Stream response directly (SSE for Claude responses)
-      proxyRes.pipe(res)
+      // Tee the response: write to client (live streaming preserved) AND feed
+      // a parser that pulls token usage out of the SSE / JSON body. Only do
+      // this for /v1/messages where Anthropic emits usage; everything else
+      // just passes through directly to keep the hot path cheap.
+      const isMessages = pathname.startsWith('/v1/messages')
+      const parser = isMessages && status >= 200 && status < 300 ? new SSEUsageParser() : null
 
       let finalized = false
       const finalize = () => {
         if (finalized) return
         finalized = true
+        const usage = parser?.result()
+        const cost = usage && usage.model
+          ? computeCost(usage.model, usage)
+          : 0
         recordRequest({
           ts: startedAt,
           client: clientName,
@@ -206,13 +203,38 @@ async function handleRequest(
           path: pathname,
           status,
           durationMs: Date.now() - startedAt,
+          model: usage?.model,
+          inputTokens: usage?.inputTokens,
+          outputTokens: usage?.outputTokens,
+          cacheReadTokens: usage?.cacheReadTokens,
+          cacheCreationTokens: usage?.cacheCreationTokens,
+          costUsd: cost,
         })
         if (config.logging.audit) {
           audit(clientName, method, path, status)
         }
       }
-      proxyRes.on('end', finalize)
-      proxyRes.on('close', finalize)
+
+      if (parser) {
+        proxyRes.on('data', (chunk: Buffer) => {
+          res.write(chunk)
+          parser.feed(chunk)
+        })
+        proxyRes.on('end', () => {
+          parser.end()
+          res.end()
+          finalize()
+        })
+        proxyRes.on('error', (err) => {
+          log('error', `Upstream stream error: ${err.message}`)
+          res.end()
+          finalize()
+        })
+      } else {
+        proxyRes.pipe(res)
+        proxyRes.on('end', finalize)
+        proxyRes.on('close', finalize)
+      }
     },
   )
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -152,9 +152,22 @@ async function handleRequest(
     config,
   )
 
-  // Inject the real OAuth token via x-api-key (Anthropic uses this header for both
-  // API keys and OAuth tokens, distinguished by prefix: sk-ant-api03- vs sk-ant-oat01-)
-  rewrittenHeaders['x-api-key'] = oauthToken
+  // Inject the OAuth access_token. Anthropic OAuth tokens (sk-ant-oat01-) must
+  // be sent via Authorization: Bearer with the anthropic-beta: oauth-2025-04-20
+  // flag — sending them via x-api-key returns 401 "Invalid authentication
+  // credentials". rewriteHeaders() already stripped any inbound auth headers.
+  delete rewrittenHeaders['x-api-key']
+  rewrittenHeaders['authorization'] = `Bearer ${oauthToken}`
+
+  const oauthBetaFlag = 'oauth-2025-04-20'
+  const existingBeta = rewrittenHeaders['anthropic-beta']
+  if (existingBeta) {
+    if (!existingBeta.split(',').map((s) => s.trim()).includes(oauthBetaFlag)) {
+      rewrittenHeaders['anthropic-beta'] = `${existingBeta},${oauthBetaFlag}`
+    }
+  } else {
+    rewrittenHeaders['anthropic-beta'] = oauthBetaFlag
+  }
 
   // Forward to upstream
   const upstreamUrl = new URL(path, upstream)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -154,9 +154,22 @@ async function handleRequest(
     config,
   )
 
-  // Inject the real OAuth token via x-api-key (Anthropic uses this header for both
-  // API keys and OAuth tokens, distinguished by prefix: sk-ant-api03- vs sk-ant-oat01-)
-  rewrittenHeaders['x-api-key'] = oauthToken
+  // Inject the OAuth access_token. Anthropic OAuth tokens (sk-ant-oat01-) must
+  // be sent via Authorization: Bearer with the anthropic-beta: oauth-2025-04-20
+  // flag — sending them via x-api-key returns 401 "Invalid authentication
+  // credentials". rewriteHeaders() already stripped any inbound auth headers.
+  delete rewrittenHeaders['x-api-key']
+  rewrittenHeaders['authorization'] = `Bearer ${oauthToken}`
+
+  const oauthBetaFlag = 'oauth-2025-04-20'
+  const existingBeta = rewrittenHeaders['anthropic-beta']
+  if (existingBeta) {
+    if (!existingBeta.split(',').map((s) => s.trim()).includes(oauthBetaFlag)) {
+      rewrittenHeaders['anthropic-beta'] = `${existingBeta},${oauthBetaFlag}`
+    }
+  } else {
+    rewrittenHeaders['anthropic-beta'] = oauthBetaFlag
+  }
 
   // Forward to upstream
   const upstreamUrl = new URL(path, upstream)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,6 +9,16 @@ import { getAccessToken } from './oauth.js'
 import { rewriteBody, rewriteHeaders } from './rewriter.js'
 import { audit, log } from './logger.js'
 import { getProxyAgent } from './proxy-agent.js'
+import { recordRequest, getMetricsSnapshot } from './metrics.js'
+import { renderDashboard, renderLogin } from './dashboard.js'
+import { authenticateUser } from './users.js'
+import {
+  createSessionCookie,
+  setCookieHeader,
+  clearCookieHeader,
+  getSessionFromRequest,
+} from './session.js'
+import { addClient, listClients, removeClient, buildLauncherScript } from './clients.js'
 
 export function startProxy(config: Config) {
   initAuth(config)
@@ -50,12 +60,14 @@ async function handleRequest(
 ) {
   const method = req.method || 'GET'
   const path = req.url || '/'
+  const pathname = path.split('?')[0]
   const clientIp = req.socket.remoteAddress || 'unknown'
+  const startedAt = Date.now()
 
   log('info', `← ${method} ${path} from ${clientIp}`)
 
   // Health check - no auth required
-  if (path === '/_health') {
+  if (pathname === '/_health') {
     const oauthOk = !!getAccessToken()
     const status = oauthOk ? 200 : 503
     res.writeHead(status, { 'Content-Type': 'application/json' })
@@ -70,8 +82,22 @@ async function handleRequest(
     return
   }
 
+  // Login page + session-protected dashboard
+  if (
+    pathname === '/login' ||
+    pathname === '/logout' ||
+    pathname === '/dashboard' ||
+    pathname === '/' ||
+    pathname === '/_metrics' ||
+    pathname === '/api/clients' ||
+    pathname.startsWith('/api/clients/')
+  ) {
+    await handleDashboardArea(req, res, pathname, method)
+    return
+  }
+
   // Dry-run verification - shows what would be rewritten (auth required)
-  if (path === '/_verify') {
+  if (pathname === '/_verify') {
     const clientName = authenticate(req)
     if (!clientName) {
       res.writeHead(401, { 'Content-Type': 'application/json' })
@@ -156,9 +182,24 @@ async function handleRequest(
       // Stream response directly (SSE for Claude responses)
       proxyRes.pipe(res)
 
-      if (config.logging.audit) {
-        audit(clientName, method, path, status)
+      let finalized = false
+      const finalize = () => {
+        if (finalized) return
+        finalized = true
+        recordRequest({
+          ts: startedAt,
+          client: clientName,
+          method,
+          path: pathname,
+          status,
+          durationMs: Date.now() - startedAt,
+        })
+        if (config.logging.audit) {
+          audit(clientName, method, path, status)
+        }
       }
+      proxyRes.on('end', finalize)
+      proxyRes.on('close', finalize)
     },
   )
 
@@ -168,6 +209,14 @@ async function handleRequest(
       res.writeHead(502, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({ error: 'Bad gateway', detail: err.message }))
     }
+    recordRequest({
+      ts: startedAt,
+      client: clientName,
+      method,
+      path: pathname,
+      status: 502,
+      durationMs: Date.now() - startedAt,
+    })
     if (config.logging.audit) {
       audit(clientName, method, path, 502)
     }
@@ -222,5 +271,222 @@ function buildVerificationPayload(config: Config) {
       system_prompt_env: rewritten.system[0]?.text ?? '(empty)',
       system_block_count: rewritten.system.length,
     },
+  }
+}
+
+function isSecureRequest(req: IncomingMessage): boolean {
+  const proto = req.headers['x-forwarded-proto']
+  if (typeof proto === 'string' && proto.split(',')[0].trim() === 'https') return true
+  return (req.socket as { encrypted?: boolean }).encrypted === true
+}
+
+async function readBody(req: IncomingMessage, limit = 64 * 1024): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  let total = 0
+  for await (const chunk of req) {
+    const buf = typeof chunk === 'string' ? Buffer.from(chunk) : chunk
+    total += buf.length
+    if (total > limit) throw new Error('body too large')
+    chunks.push(buf)
+  }
+  return Buffer.concat(chunks)
+}
+
+async function handleDashboardArea(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  method: string,
+) {
+  const secure = isSecureRequest(req)
+
+  // Root → redirect to dashboard or login
+  if (pathname === '/') {
+    const session = getSessionFromRequest(req)
+    res.writeHead(302, { Location: session ? '/dashboard' : '/login' })
+    res.end()
+    return
+  }
+
+  // Login: GET shows form, POST authenticates
+  if (pathname === '/login') {
+    if (method === 'GET') {
+      // If already logged in, send to dashboard
+      if (getSessionFromRequest(req)) {
+        res.writeHead(302, { Location: '/dashboard' })
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      res.end(renderLogin())
+      return
+    }
+    if (method === 'POST') {
+      let body: Buffer
+      try {
+        body = await readBody(req)
+      } catch {
+        res.writeHead(413, { 'Content-Type': 'text/plain' })
+        res.end('Payload too large')
+        return
+      }
+      const params = new URLSearchParams(body.toString('utf-8'))
+      const username = (params.get('username') || '').trim()
+      const password = params.get('password') || ''
+      if (!username || !password) {
+        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(renderLogin('Username and password required'))
+        return
+      }
+      const user = authenticateUser(username, password)
+      if (!user) {
+        log('warn', `Failed login for "${username}" from ${req.socket.remoteAddress}`)
+        res.writeHead(401, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.end(renderLogin('Invalid username or password'))
+        return
+      }
+      const cookie = createSessionCookie(user.username)
+      log('info', `User "${user.username}" logged in`)
+      res.writeHead(302, {
+        Location: '/dashboard',
+        'Set-Cookie': setCookieHeader(cookie, secure),
+      })
+      res.end()
+      return
+    }
+    res.writeHead(405, { Allow: 'GET, POST' })
+    res.end()
+    return
+  }
+
+  // Logout: clear cookie, redirect to login
+  if (pathname === '/logout') {
+    res.writeHead(302, {
+      Location: '/login',
+      'Set-Cookie': clearCookieHeader(),
+    })
+    res.end()
+    return
+  }
+
+  // Session-protected: dashboard + metrics
+  const session = getSessionFromRequest(req)
+  if (!session) {
+    if (pathname === '/_metrics') {
+      res.writeHead(401, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Unauthorized' }))
+    } else {
+      res.writeHead(302, { Location: '/login' })
+      res.end()
+    }
+    return
+  }
+
+  if (pathname === '/dashboard') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(renderDashboard())
+    return
+  }
+
+  if (pathname === '/_metrics') {
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+    res.end(JSON.stringify(getMetricsSnapshot()))
+    return
+  }
+
+  if (pathname === '/api/clients') {
+    if (method === 'GET') {
+      const clients = listClients().map((c) => ({
+        name: c.name,
+        token_preview: c.token.slice(0, 8) + '…' + c.token.slice(-4),
+      }))
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ clients }))
+      return
+    }
+    if (method === 'POST') {
+      let body: Buffer
+      try {
+        body = await readBody(req)
+      } catch {
+        res.writeHead(413, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Payload too large' }))
+        return
+      }
+      let payload: { name?: string; gateway_addr?: string; scheme?: string; format?: string }
+      try {
+        payload = JSON.parse(body.toString('utf-8'))
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Invalid JSON' }))
+        return
+      }
+      const name = (payload.name || '').trim()
+      const scheme = payload.scheme === 'http' ? 'http' : 'https'
+      const gatewayAddr =
+        (payload.gateway_addr || '').trim() ||
+        (typeof req.headers.host === 'string' ? req.headers.host : 'localhost:8443')
+      if (!name) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'name required' }))
+        return
+      }
+      let entry
+      try {
+        entry = addClient(name)
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: err instanceof Error ? err.message : 'failed' }))
+        return
+      }
+      log('info', `User "${session.u}" added client "${entry.name}"`)
+      const script = buildLauncherScript({
+        name: entry.name,
+        token: entry.token,
+        gatewayAddr,
+        scheme,
+      })
+      if (payload.format === 'json') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ name: entry.name, token: entry.token, script }))
+        return
+      }
+      res.writeHead(200, {
+        'Content-Type': 'application/x-shellscript; charset=utf-8',
+        'Content-Disposition': `attachment; filename="cc-${entry.name}"`,
+        'X-Client-Token': entry.token,
+      })
+      res.end(script)
+      return
+    }
+    res.writeHead(405, { Allow: 'GET, POST' })
+    res.end()
+    return
+  }
+
+  if (pathname.startsWith('/api/clients/')) {
+    const name = decodeURIComponent(pathname.slice('/api/clients/'.length))
+    if (method === 'DELETE') {
+      let removed = false
+      try {
+        removed = removeClient(name)
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: err instanceof Error ? err.message : 'failed' }))
+        return
+      }
+      if (!removed) {
+        res.writeHead(404, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'not found' }))
+        return
+      }
+      log('info', `User "${session.u}" removed client "${name}"`)
+      res.writeHead(204)
+      res.end()
+      return
+    }
+    res.writeHead(405, { Allow: 'DELETE' })
+    res.end()
+    return
   }
 }

--- a/src/scripts/add-user.ts
+++ b/src/scripts/add-user.ts
@@ -45,7 +45,10 @@ async function main() {
     process.exit(1)
   }
 
-  const configPath = process.argv[3]
+  const configPath =
+    process.argv[3] ||
+    process.env.CCG_CONFIG_PATH ||
+    '/app/data/config.yaml'
   const config = loadConfig(configPath)
   if (!config.db?.path) {
     console.error('config: db.path is required')

--- a/src/scripts/add-user.ts
+++ b/src/scripts/add-user.ts
@@ -1,0 +1,85 @@
+import { loadConfig } from '../config.js'
+import { initDb } from '../db.js'
+import { createUser, findUser } from '../users.js'
+import { stdin, stdout } from 'process'
+
+async function promptPassword(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    process.stdout.write(question)
+    let buf = ''
+    const wasRaw = stdin.isRaw
+    const onData = (ch: Buffer) => {
+      for (const byte of ch) {
+        if (byte === 0x0d || byte === 0x0a) {
+          stdin.removeListener('data', onData)
+          if (stdin.setRawMode) stdin.setRawMode(wasRaw)
+          stdin.pause()
+          process.stdout.write('\n')
+          resolve(buf)
+          return
+        }
+        if (byte === 0x03) {
+          process.stdout.write('\n')
+          process.exit(130)
+        }
+        if (byte === 0x7f || byte === 0x08) {
+          buf = buf.slice(0, -1)
+          continue
+        }
+        if (byte >= 0x20) {
+          buf += String.fromCharCode(byte)
+        }
+      }
+    }
+    if (stdin.setRawMode) stdin.setRawMode(true)
+    stdin.resume()
+    stdin.on('data', onData)
+  })
+}
+
+async function main() {
+  const username = process.argv[2]
+  if (!username) {
+    console.error('Usage: npm run add-user <username> [-- <config-path>]')
+    console.error('Or set PASSWORD env var to skip the interactive prompt')
+    process.exit(1)
+  }
+
+  const configPath = process.argv[3]
+  const config = loadConfig(configPath)
+  if (!config.db?.path) {
+    console.error('config: db.path is required')
+    process.exit(1)
+  }
+
+  initDb(config.db.path)
+
+  if (findUser(username)) {
+    console.error(`User "${username}" already exists`)
+    process.exit(1)
+  }
+
+  let password = process.env.PASSWORD
+  if (!password) {
+    password = await promptPassword(`Password for ${username}: `)
+    const confirm = await promptPassword('Confirm password: ')
+    if (password !== confirm) {
+      console.error('Passwords do not match')
+      process.exit(1)
+    }
+  }
+
+  if (!password || password.length < 8) {
+    console.error('Password must be at least 8 characters')
+    process.exit(1)
+  }
+
+  const user = createUser(username, password)
+  console.log(`\nCreated user "${user.username}" (id=${user.id})`)
+  console.log(`Login at: https://<your-domain>/login`)
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err instanceof Error ? err.message : err}`)
+  process.exit(1)
+})

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,0 +1,82 @@
+import { createHmac, timingSafeEqual } from 'crypto'
+import type { IncomingMessage } from 'http'
+import { getSessionSecret } from './db.js'
+
+const COOKIE_NAME = 'ccg_session'
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000  // 7 days
+
+interface SessionPayload {
+  u: string  // username
+  e: number  // expiry timestamp ms
+}
+
+function b64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function b64urlDecode(s: string): Buffer {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4))
+  return Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64')
+}
+
+function sign(payload: string): string {
+  return b64url(createHmac('sha256', getSessionSecret()).update(payload).digest())
+}
+
+export function createSessionCookie(username: string): string {
+  const payload: SessionPayload = { u: username, e: Date.now() + SESSION_TTL_MS }
+  const body = b64url(Buffer.from(JSON.stringify(payload), 'utf-8'))
+  const sig = sign(body)
+  return `${body}.${sig}`
+}
+
+export function verifySessionToken(token: string): SessionPayload | null {
+  const dot = token.indexOf('.')
+  if (dot === -1) return null
+  const body = token.slice(0, dot)
+  const sig = token.slice(dot + 1)
+  const expected = sign(body)
+  const sigBuf = Buffer.from(sig)
+  const expectedBuf = Buffer.from(expected)
+  if (sigBuf.length !== expectedBuf.length) return null
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return null
+  try {
+    const payload = JSON.parse(b64urlDecode(body).toString('utf-8')) as SessionPayload
+    if (typeof payload.u !== 'string' || typeof payload.e !== 'number') return null
+    if (payload.e < Date.now()) return null
+    return payload
+  } catch {
+    return null
+  }
+}
+
+export function getSessionFromRequest(req: IncomingMessage): SessionPayload | null {
+  const cookieHeader = req.headers.cookie
+  if (!cookieHeader) return null
+  const parts = cookieHeader.split(';').map(s => s.trim())
+  for (const part of parts) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    const name = part.slice(0, eq)
+    if (name !== COOKIE_NAME) continue
+    const value = part.slice(eq + 1)
+    return verifySessionToken(value)
+  }
+  return null
+}
+
+export function setCookieHeader(token: string, secure: boolean): string {
+  const attrs = [
+    `${COOKIE_NAME}=${token}`,
+    'HttpOnly',
+    'SameSite=Lax',
+    'Path=/',
+    `Max-Age=${Math.floor(SESSION_TTL_MS / 1000)}`,
+  ]
+  if (secure) attrs.push('Secure')
+  return attrs.join('; ')
+}
+
+export function clearCookieHeader(): string {
+  return `${COOKIE_NAME}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0`
+}

--- a/src/usage-parser.ts
+++ b/src/usage-parser.ts
@@ -1,0 +1,149 @@
+/**
+ * Streaming SSE parser for Anthropic /v1/messages responses.
+ *
+ * Anthropic streams events like:
+ *   event: message_start
+ *   data: {"type":"message_start","message":{"id":"...","model":"claude-...","usage":{"input_tokens":N,...}}}
+ *
+ *   event: content_block_delta
+ *   data: {"type":"content_block_delta",...}
+ *
+ *   event: message_delta
+ *   data: {"type":"message_delta","usage":{"output_tokens":N}}
+ *
+ *   event: message_stop
+ *   data: {"type":"message_stop"}
+ *
+ * `message_start` carries the model id and initial usage (input + cache fields).
+ * `message_delta` is emitted just before stop and carries the final output_tokens.
+ *
+ * Non-streaming responses (rare for claude-code) return a single JSON body
+ * with `usage` at the root — handle both.
+ */
+export interface ParsedUsage {
+  model: string
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+}
+
+export class SSEUsageParser {
+  private buffer = ''
+  private model = ''
+  private inputTokens = 0
+  private outputTokens = 0
+  private cacheReadTokens = 0
+  private cacheCreationTokens = 0
+  private isStreaming = false
+
+  feed(chunk: Buffer | string): void {
+    this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf-8')
+
+    // Detect SSE format on first useful bytes
+    if (!this.isStreaming) {
+      const trimmed = this.buffer.trimStart()
+      if (trimmed.startsWith('event:') || trimmed.startsWith('data:')) {
+        this.isStreaming = true
+      }
+    }
+
+    if (this.isStreaming) {
+      this.flushSseEvents()
+    }
+  }
+
+  /** Call when the response stream has ended. */
+  end(): void {
+    if (this.isStreaming) {
+      // Drain any partial event left in buffer (shouldn't usually happen)
+      this.flushSseEvents()
+      return
+    }
+    // Non-streaming path: buffer holds a single JSON document
+    const text = this.buffer.trim()
+    if (!text) return
+    try {
+      const obj = JSON.parse(text)
+      this.absorbMessageObject(obj)
+    } catch {
+      // body wasn't JSON or got truncated — just leave usage at zero
+    }
+  }
+
+  result(): ParsedUsage {
+    return {
+      model: this.model,
+      inputTokens: this.inputTokens,
+      outputTokens: this.outputTokens,
+      cacheReadTokens: this.cacheReadTokens,
+      cacheCreationTokens: this.cacheCreationTokens,
+    }
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  private flushSseEvents(): void {
+    let idx
+    while ((idx = this.buffer.indexOf('\n\n')) !== -1) {
+      const block = this.buffer.slice(0, idx)
+      this.buffer = this.buffer.slice(idx + 2)
+      this.parseEventBlock(block)
+    }
+    // Some servers use \r\n\r\n
+    while ((idx = this.buffer.indexOf('\r\n\r\n')) !== -1) {
+      const block = this.buffer.slice(0, idx)
+      this.buffer = this.buffer.slice(idx + 4)
+      this.parseEventBlock(block)
+    }
+  }
+
+  private parseEventBlock(block: string): void {
+    // Block is one or more lines like "event: foo" / "data: {...}"
+    const lines = block.split(/\r?\n/)
+    let dataPayload = ''
+    for (const line of lines) {
+      if (line.startsWith('data:')) {
+        // Per SSE spec, multiple data: lines join with \n
+        dataPayload += (dataPayload ? '\n' : '') + line.slice(5).trimStart()
+      }
+    }
+    if (!dataPayload || dataPayload === '[DONE]') return
+    try {
+      const obj = JSON.parse(dataPayload)
+      this.absorbStreamingEvent(obj)
+    } catch {
+      // ignore malformed
+    }
+  }
+
+  private absorbStreamingEvent(obj: any): void {
+    if (!obj || typeof obj !== 'object') return
+    if (obj.type === 'message_start' && obj.message) {
+      if (typeof obj.message.model === 'string') this.model = obj.message.model
+      this.absorbUsage(obj.message.usage)
+    } else if (obj.type === 'message_delta') {
+      this.absorbUsage(obj.usage)
+    }
+  }
+
+  private absorbMessageObject(obj: any): void {
+    if (!obj || typeof obj !== 'object') return
+    if (typeof obj.model === 'string') this.model = obj.model
+    this.absorbUsage(obj.usage)
+  }
+
+  private absorbUsage(u: any): void {
+    if (!u || typeof u !== 'object') return
+    // message_delta only sends fields that changed — take max so we keep the
+    // largest value seen for each counter (handles partial updates safely).
+    if (typeof u.input_tokens === 'number')
+      this.inputTokens = Math.max(this.inputTokens, u.input_tokens)
+    if (typeof u.output_tokens === 'number')
+      this.outputTokens = Math.max(this.outputTokens, u.output_tokens)
+    if (typeof u.cache_read_input_tokens === 'number')
+      this.cacheReadTokens = Math.max(this.cacheReadTokens, u.cache_read_input_tokens)
+    if (typeof u.cache_creation_input_tokens === 'number')
+      this.cacheCreationTokens = Math.max(this.cacheCreationTokens, u.cache_creation_input_tokens)
+  }
+}

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,0 +1,70 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'crypto'
+import { getDb } from './db.js'
+
+const SCRYPT_N = 16384
+const SCRYPT_r = 8
+const SCRYPT_p = 1
+const KEY_LEN = 64
+const SALT_LEN = 16
+
+export interface User {
+  id: number
+  username: string
+  password_hash: string
+  created_at: number
+}
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(SALT_LEN)
+  const derived = scryptSync(password, salt, KEY_LEN, { N: SCRYPT_N, r: SCRYPT_r, p: SCRYPT_p })
+  return `scrypt$${SCRYPT_N}$${SCRYPT_r}$${SCRYPT_p}$${salt.toString('hex')}$${derived.toString('hex')}`
+}
+
+function verifyPassword(password: string, stored: string): boolean {
+  const parts = stored.split('$')
+  if (parts.length !== 6 || parts[0] !== 'scrypt') return false
+  const N = parseInt(parts[1], 10)
+  const r = parseInt(parts[2], 10)
+  const p = parseInt(parts[3], 10)
+  const salt = Buffer.from(parts[4], 'hex')
+  const expected = Buffer.from(parts[5], 'hex')
+  const derived = scryptSync(password, salt, expected.length, { N, r, p })
+  if (derived.length !== expected.length) return false
+  return timingSafeEqual(derived, expected)
+}
+
+export function createUser(username: string, password: string): User {
+  if (!/^[a-zA-Z0-9_.-]{3,32}$/.test(username)) {
+    throw new Error('username must be 3-32 chars, [a-zA-Z0-9_.-]')
+  }
+  if (password.length < 8) {
+    throw new Error('password must be at least 8 characters')
+  }
+  const db = getDb()
+  const hash = hashPassword(password)
+  const now = Date.now()
+  const result = db
+    .prepare('INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, ?)')
+    .run(username, hash, now)
+  return { id: Number(result.lastInsertRowid), username, password_hash: hash, created_at: now }
+}
+
+export function findUser(username: string): User | null {
+  const row = getDb().prepare('SELECT * FROM users WHERE username = ?').get(username) as User | undefined
+  return row ?? null
+}
+
+export function authenticateUser(username: string, password: string): User | null {
+  const user = findUser(username)
+  if (!user) {
+    // Constant-time-ish: still run a hash to avoid leaking existence via timing
+    scryptSync(password, randomBytes(SALT_LEN), KEY_LEN, { N: SCRYPT_N, r: SCRYPT_r, p: SCRYPT_p })
+    return null
+  }
+  return verifyPassword(password, user.password_hash) ? user : null
+}
+
+export function countUsers(): number {
+  const row = getDb().prepare('SELECT COUNT(*) as c FROM users').get() as { c: number }
+  return row.c
+}


### PR DESCRIPTION
## Summary

Bundle of features and fixes accumulated on top of v0.2.0:

- **Dashboard web** at `/dashboard` with login (`/login`): in-app client management, per-request token usage (input / output / cache as separate columns), and cost summary by period (today / 7d / 30d / all time).
- **Auto-bootstrap & Coolify deploy**: gateway auto-generates `config.yaml` on first start from `CCG_REFRESH_TOKEN` or a mounted `claude-credentials.json`. `docker-compose.yml` wired for Traefik/Coolify with host credentials mount.
- **Token lifecycle hardening**: rotated OAuth tokens persisted back to `config.yaml` so restarts survive; OAuth forwarded via `Authorization: Bearer` + `anthropic-beta`; `auth.tokens` hot-reloaded on config change.
- **Tooling**: `gen-config.sh` to generate `config.yaml` from an existing Claude login; `add-user` npm script uses compiled JS so it works inside the prod image; launcher script output now matches `scripts/add-client.sh` 1:1.
- **Docs**: Vietnamese deploy & local-usage guide (`README.vi.md`).

## Test plan

- [ ] `npm install && bash scripts/quick-setup.sh` brings up gateway and serves a working launcher
- [ ] `npm run add-user -- admin` creates a dashboard user and `/login` works
- [ ] Dashboard shows request count + cost summary after a few Claude Code requests
- [ ] `docker compose up -d` on a fresh host with mounted `~/.claude/.credentials.json` auto-generates `config.yaml`
- [ ] Adding a client via dashboard hot-reloads without restart
- [ ] OAuth refresh persists rotated `refresh_token` back to `config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)